### PR TITLE
Add selectable sort-free X-ray rasterization backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,26 @@ We present 4DRGS, the first Gaussian splatting-based framework for efficient 3D 
 ![](./assest/overview.png)
 
 ## Updated Feature
+- **[2026-08-24]** We introduce sort-free X-ray rasterization, which removes unnecessary depth sorting for additive X-ray line-integral accumulation. On case2 with 30 input views, it reduces runtime by 14.9%--15.4% (1.17x--1.18x speedup) on a local NVIDIA RTX 4060 Ti while maintaining comparable PSNR and SSIM.
 - **[2025-11-09]** We now support [LEAP toolbox](https://github.com/LLNL/leap) for FDK reconstruction. [TIGRE toolbox](https://github.com/CERN/TIGRE) may encounter a CUDA error as reported in [issue #3](https://github.com/ShanghaiTech-IMPACT/4DRGS/issues/3#issue-3094309948). You can select the desired toolbox in `arguments/__init__.py` via `ModelParams.fdk_toolbox`.
 - **[2025-08-07]** tiny-cuda-nn now comes with a just-in-time (JIT) compilation mode. We have updated this feature in `scene/field.py` by setting `model.jit_fusion = tcnn.supports_jit_fusion()`, which provides some speed improvements. Note that `tinycudann>=2.0` is required. Results in our paper is reported with `tinycudann==1.7`.
+
+## Sort-free X-ray rasterization
+X-ray rasterization in 4DRGS is an additive line-integral accumulation, so its result does not depend on the depth order of Gaussians. The sort-free backend removes tile duplication, prefix-sum, and depth-sorting stages. It is the default backend; the original implementation remains available for comparison:
+
+    --rasterizer_backend sort_free  # default
+    --rasterizer_backend legacy
+
+The following results were measured locally on case2 with 30 input views and an NVIDIA RTX 4060 Ti:
+
+| Iterations / ADC until | Backend | Runtime (s) | Iteration/s | ms/iteration | Eval PSNR | Eval SSIM |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| 10k / 5k | Legacy | 453.10 | 22.07 | 45.31 | 36.343 | 0.9026 |
+| 10k / 5k | Sort-free | 383.51 | 26.07 | 38.35 | 36.349 | 0.9021 |
+| 30k / 15k | Legacy | 1380.66 | 21.73 | 46.02 | 36.343 | 0.9032 |
+| 30k / 15k | Sort-free | 1175.09 | 25.53 | 39.17 | 36.407 | 0.9031 |
+
+The runtime reported in the paper was measured on an NVIDIA RTX 3090 and includes the final voxelization and rendering stages; the local RTX 4060 Ti measurements above should therefore not be compared directly with the paper's absolute runtime.
 
 ## Setup
 First clone this repo. And then set up an environment and install packages. C++ Compiler is required. We used Visual Studio 2019 for Windows and GCC 8.3.0 for Linux.
@@ -29,7 +47,8 @@ First clone this repo. And then set up an environment and install packages. C++ 
     cd tiny-cuda-nn/bindings/torch
     python setup.py install
     cd ../../..
-    pip install submodules/diff-Xray-gaussian-rasterization-voxelization
+    pip install submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree
+    pip install submodules/diff-Xray-gaussian-rasterization-voxelization-legacy
     pip install submodules/simple-knn
 
 Please refer to [LEAP toolbox](https://github.com/LLNL/leap) for your best installation. The following is what I do.

--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -62,6 +62,7 @@ class PipelineParams(ParamGroup):
     def __init__(self, parser):
         self.compute_cov3D_python = False
         self.debug = False
+        self.rasterizer_backend = "sort_free"
         super().__init__(parser, "Pipeline Parameters")
 
 

--- a/gaussian_renderer_voxelizer/__init__.py
+++ b/gaussian_renderer_voxelizer/__init__.py
@@ -12,15 +12,40 @@
 import torch
 import math
 from diff_Xray_gaussian_rasterization_voxelization import (
-    GaussianRasterizationSettings,
-    GaussianRasterizer,
-    GaussianVoxelizationSettings,
-    GaussianVoxelizer,
+    GaussianRasterizationSettings as SortFreeRasterizationSettings,
+    GaussianRasterizer as SortFreeRasterizer,
+    GaussianVoxelizationSettings as SortFreeVoxelizationSettings,
+    GaussianVoxelizer as SortFreeVoxelizer,
+)
+from diff_Xray_gaussian_rasterization_voxelization_legacy import (
+    GaussianRasterizationSettings as LegacyRasterizationSettings,
+    GaussianRasterizer as LegacyRasterizer,
+    GaussianVoxelizationSettings as LegacyVoxelizationSettings,
+    GaussianVoxelizer as LegacyVoxelizer,
 )
 from scene.gaussian_model import GaussianModel
 from scene.cameras import Camera
 import numpy as np
 import copy
+
+
+def _backend_classes(pipe):
+    backend = getattr(pipe, "rasterizer_backend", "sort_free")
+    if backend == "sort_free":
+        return (
+            SortFreeRasterizationSettings,
+            SortFreeRasterizer,
+            SortFreeVoxelizationSettings,
+            SortFreeVoxelizer,
+        )
+    if backend == "legacy":
+        return (
+            LegacyRasterizationSettings,
+            LegacyRasterizer,
+            LegacyVoxelizationSettings,
+            LegacyVoxelizer,
+        )
+    raise ValueError(f"Unknown rasterizer backend: {backend}")
 
 def query(pc: GaussianModel, 
           timestamp,
@@ -38,7 +63,8 @@ def query(pc: GaussianModel,
     """
 
     
-    voxel_settings = GaussianVoxelizationSettings(
+    _, _, VoxelizationSettings, Voxelizer = _backend_classes(pipe)
+    voxel_settings = VoxelizationSettings(
         scale_modifier=scaling_modifier,
         nVoxel_x=int(nVoxel[0]),
         nVoxel_y=int(nVoxel[1]),
@@ -52,7 +78,7 @@ def query(pc: GaussianModel,
         prefiltered=False,
         debug=pipe.debug,
     )
-    voxelizer = GaussianVoxelizer(voxel_settings=voxel_settings)
+    voxelizer = Voxelizer(voxel_settings=voxel_settings)
 
     means3D = pc.get_xyz
 
@@ -112,7 +138,8 @@ def render(
     tanfovx = math.tan(viewpoint_camera.FoVx * 0.5)
     tanfovy = math.tan(viewpoint_camera.FoVy * 0.5)
 
-    raster_settings = GaussianRasterizationSettings(
+    RasterizationSettings, Rasterizer, _, _ = _backend_classes(pipe)
+    raster_settings = RasterizationSettings(
         image_height=int(viewpoint_camera.image_height),
         image_width=int(viewpoint_camera.image_width),
         tanfovx=tanfovx,
@@ -126,7 +153,7 @@ def render(
         debug=pipe.debug,
     )
 
-    rasterizer = GaussianRasterizer(raster_settings=raster_settings)
+    rasterizer = Rasterizer(raster_settings=raster_settings)
 
     means3D = pc.get_xyz
     means2D = screenspace_points
@@ -171,12 +198,4 @@ def render(
         cov3D_precomp=cov3D_precomp,
     )
     # Those Gaussians that were frustum culled or had a radius of 0 were not visible.
-    # They will be excluded from value updates used in the splitting criteria.
-    return {
-        "render": rendered_image,
-        "viewspace_points": screenspace_points,
-        "visibility_filter": radii > 0,
-        "radii": radii,
-        "render_geo": render_others[0:1],
-        "dummy_opacity": dummy_opacity,
-    }
+    # They will be excluded from valu×N¸êÚ$z{-®éÜj×ÄÔÀÀÀ4(€€€€€€€Í•±˜¹‘•¹Í¥™å}™É½µ}¥Ñ•È€ô€ÔÀÀ4(€€€€€€€Í•±˜¹‘•¹Í¥™å}É…‘}Ñ¡É•Í¡½±‘}¥¹¥Ð€ô€À¸ÀÀÀÄ€€Œ€À¸ÀÀÀÄ4(€€€€€€€Í•±˜¹‘•¹Í¥™å}É…‘}Ñ¡É•Í¡½±‘}™¥¹…°€ô€À¸ÀÀÀÄ€Œ€À¸ÀÀÀÀØ4(€€€€€€€Í•±˜¹Á•É•¹Ñ}‘•¹Í•}¥¹¥Ð€ô€È¸Ô€€Œ¹Õ´½˜Ù½á•±Ì4(€€€€€€€Í•±˜¹Á•É•¹Ñ}‘•¹Í•}™¥¹…°€ô€À¸Ô€€Œ¹Õ´½˜Ù½á•±Ì4(€€€€€€€Í•±˜¹É…¹‘½µ}ÁÉÕ¹”€ô…±Í”4(€€€€€€€Í•±˜¹Á•É•¹Ñ}É…¹‘½µ}ÁÉÕ¹•}¥¹¥Ð€ô€À¸Àà€€Œ€À¸Ä4(€€€€€€€Í•±˜¹Á•É•¹Ñ}É…¹‘½µ}ÁÉÕ¹•}™¥¹…°€ô€À¸Àà€€Œ€À¸ÀØ4(€€€€€€€Í•±˜¹½Á…¥Ñå}ÁÉÕ¹”€ô…±Í”4(€€€€€€€Í•±˜¹µ¥¹}½Á…¥Ñå}¥¹¥Ð€ô€Å”´Ø4(€€€€€€€Í•±˜¹µ¥¹}½Á…¥Ñå}™¥¹…°€ô€Å”´Ø4(€€€€€€€Í•±˜¹…Ù½Á…¥Ñå}ÁÉÕ¹”€ôQÉÕ”4(€€€€€€€Í•±˜¹µ¥¹}…Ù½Á…¥Ñå}¥¹¥Ð€ô€Å”´Ø4(€€€€€€€Í•±˜¹µ¥¹}…Ù½Á…¥Ñå}™¥¹…°€ô€Å”´Ø4(€€€€€€€Í•±˜¹µ…á}ÍÉ••¹}Í¥é”€ô9½¹”4(€€€€€€€Í•±˜¹™±½Ý}½¹Í¥ÍÑ•¹ä€ôQÉÕ”4(€€€€€€€Í•±˜¹QA}ÍÑ€ô€Ä¸À4(€€€€€€€ÍÕÁ•È ¤¹}}¥¹¥Ñ}|¡Á…ÉÍ•È°€‰=ÁÑ¥µ¥é…Ñ¥½¸A…É…µ•Ñ•ÉÌˆ¤4(4)‘•˜•Ñ}½µ‰¥¹•‘}…ÉÌ¡Á…ÉÍ•È€èÉÕµ•¹ÑA…ÉÍ•È¤è4(€€€µ‘±¹•}ÍÑÉ¥¹œ€ôÍåÌ¹…ÉÙlÄét4(€€€™™¥±•}ÍÑÉ¥¹œ€ô€‰9…µ•ÍÁ…” ¤ˆ4(€€€…ÉÍ}µ‘±¥¹”€ôÁ…ÉÍ•È¹Á…ÉÍ•}…ÉÌ¡µ‘±¹•}ÍÑÉ¥¹œ¤4(4(€€€ÑÉäè4(€€€€€€€™™¥±•Á…Ñ €ô½Ì¹Á…Ñ ¹©½¥¸¡…ÉÍ}µ‘±¥¹”¹µ½‘•±}Á…Ñ °€‰™}…ÉÌˆ¤4(€€€€€€€ÁÉ¥¹Ð ‰1½½­¥¹œ™½È½¹™¥œ™¥±”¥¸ˆ°™™¥±•Á…Ñ ¤4(€€€€€€€Ý¥Ñ ½Á•¸¡™™¥±•Á…Ñ ¤…Ì™}™¥±”è4(€€€€€€€€€€€ÁÉ¥¹Ð ‰½¹™¥œ™¥±”™½Õ¹èíôˆ¹™½Éµ…Ð¡™™¥±•Á…Ñ ¤¤4(€€€€€€€€€€€™™¥±•}ÍÑÉ¥¹œ€ô™}™¥±”¹É•… ¤4(€€€•á•ÁÐQåÁ•ÉÉ½Èè4(€€€€€€€ÁÉ¥¹Ð ‰½¹™¥œ™¥±”¹½Ð™½Õ¹…Ðˆ¤4(€€€€€€€Á…ÍÌ4(€€€…ÉÍ}™™¥±”€ô•Ù…°¡™™¥±•}ÍÑÉ¥¹œ¤4(4(€€€µ•É•‘}‘¥Ð€ôÙ…ÉÌ¡…ÉÍ}™™¥±”¤¹½Áä ¤4(€€€™½È¬±Ø¥¸Ù…ÉÌ¡…ÉÍ}µ‘±¥¹”¤¹¥Ñ•µÌ ¤è4(€€€€€€€¥˜Ø€„ô9½¹”è4(€€€€€€€€€€€µ•É•‘}‘¥Ñm­t€ôØ4(€€€É•ÑÕÉ¸9…µ•ÍÁ…” ¨©µ•É•‘}‘¥Ð¤4(4(

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/LICENSE.md
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/LICENSE.md
@@ -1,0 +1,83 @@
+Gaussian-Splatting License  
+===========================  
+
+**Inria** and **the Max Planck Institut for Informatik (MPII)** hold all the ownership rights on the *Software* named **gaussian-splatting**.  
+The *Software* is in the process of being registered with the Agence pour la Protection des  
+Programmes (APP).  
+
+The *Software* is still being developed by the *Licensor*.  
+
+*Licensor*'s goal is to allow the research community to use, test and evaluate  
+the *Software*.  
+
+## 1.  Definitions  
+
+*Licensee* means any person or entity that uses the *Software* and distributes  
+its *Work*.  
+
+*Licensor* means the owners of the *Software*, i.e Inria and MPII  
+
+*Software* means the original work of authorship made available under this  
+License ie gaussian-splatting.  
+
+*Work* means the *Software* and any additions to or derivative works of the  
+*Software* that are made available under this License.  
+
+
+## 2.  Purpose  
+This license is intended to define the rights granted to the *Licensee* by  
+Licensors under the *Software*.  
+
+## 3.  Rights granted  
+
+For the above reasons Licensors have decided to distribute the *Software*.  
+Licensors grant non-exclusive rights to use the *Software* for research purposes  
+to research users (both academic and industrial), free of charge, without right  
+to sublicense.. The *Software* may be used "non-commercially", i.e., for research  
+and/or evaluation purposes only.  
+
+Subject to the terms and conditions of this License, you are granted a  
+non-exclusive, royalty-free, license to reproduce, prepare derivative works of,  
+publicly display, publicly perform and distribute its *Work* and any resulting  
+derivative works in any form.  
+
+## 4.  Limitations  
+
+**4.1 Redistribution.** You may reproduce or distribute the *Work* only if (a) you do  
+so under this License, (b) you include a complete copy of this License with  
+your distribution, and (c) you retain without modification any copyright,  
+patent, trademark, or attribution notices that are present in the *Work*.  
+
+**4.2 Derivative Works.** You may specify that additional or different terms apply  
+to the use, reproduction, and distribution of your derivative works of the *Work*  
+("Your Terms") only if (a) Your Terms provide that the use limitation in  
+Section 2 applies to your derivative works, and (b) you identify the specific  
+derivative works that are subject to Your Terms. Notwithstanding Your Terms,  
+this License (including the redistribution requirements in Section 3.1) will  
+continue to apply to the *Work* itself.  
+
+**4.3** Any other use without of prior consent of Licensors is prohibited. Research  
+users explicitly acknowledge having received from Licensors all information  
+allowing to appreciate the adequacy between of the *Software* and their needs and  
+to undertake all necessary precautions for its execution and use.  
+
+**4.4** The *Software* is provided both as a compiled library file and as source  
+code. In case of using the *Software* for a publication or other results obtained  
+through the use of the *Software*, users are strongly encouraged to cite the  
+corresponding publications as explained in the documentation of the *Software*.  
+
+## 5.  Disclaimer  
+
+THE USER CANNOT USE, EXPLOIT OR DISTRIBUTE THE *SOFTWARE* FOR COMMERCIAL PURPOSES  
+WITHOUT PRIOR AND EXPLICIT CONSENT OF LICENSORS. YOU MUST CONTACT INRIA FOR ANY  
+UNAUTHORIZED USE: stip-sophia.transfert@inria.fr . ANY SUCH ACTION WILL  
+CONSTITUTE A FORGERY. THIS *SOFTWARE* IS PROVIDED "AS IS" WITHOUT ANY WARRANTIES  
+OF ANY NATURE AND ANY EXPRESS OR IMPLIED WARRANTIES, WITH REGARDS TO COMMERCIAL  
+USE, PROFESSIONNAL USE, LEGAL OR NOT, OR OTHER, OR COMMERCIALISATION OR  
+ADAPTATION. UNLESS EXPLICITLY PROVIDED BY LAW, IN NO EVENT, SHALL INRIA OR THE  
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR  
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  
+GOODS OR SERVICES, LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION)  
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT  
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM, OUT OF OR  
+IN CONNECTION WITH THE *SOFTWARE* OR THE USE OR OTHER DEALINGS IN THE *SOFTWARE*.  

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/README.md
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/README.md
@@ -1,0 +1,27 @@
+# Differentiable X-ray Gaussian Rasterization and Voxelization
+
+Used as the rasterization and voxelization engine for the paper "R$^2$-Gaussian: Rectifying Radiative Gaussian Splatting for Tomographic Reconstruction". The repository is adapted from [diff-gaussian-rasterization](https://github.com/graphdeco-inria/diff-gaussian-rasterization).
+
+## BibTex
+
+```sh
+@misc{zha2024r2gaussian,
+      title={R$^2$-Gaussian: Rectifying Radiative Gaussian Splatting for Tomographic Reconstruction}, 
+      author={Ruyi Zha and Tao Jun Lin and Yuanhao Cai and Jiwen Cao and Yanhao Zhang and Hongdong Li},
+      year={2024},
+      eprint={2405.20693},
+      archivePrefix={arXiv},
+      primaryClass={eess.IV}
+}
+
+@Article{kerbl3Dgaussians,
+      author       = {Kerbl, Bernhard and Kopanas, Georgios and Leimk{\"u}hler, Thomas and Drettakis, George},
+      title        = {3D Gaussian Splatting for Real-Time Radiance Field Rendering},
+      journal      = {ACM Transactions on Graphics},
+      number       = {4},
+      volume       = {42},
+      month        = {July},
+      year         = {2023},
+      url          = {https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/}
+}
+```

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/auxiliary.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/auxiliary.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef CUDA_RASTERIZER_AUXILIARY_H_INCLUDED
+#define CUDA_RASTERIZER_AUXILIARY_H_INCLUDED
+
+#include "config.h"
+#include "stdio.h"
+
+#define BLOCK_SIZE (BLOCK_X * BLOCK_Y)
+#define NUM_WARPS (BLOCK_SIZE/32)
+#define M_PI 3.141592653589793
+#define RENDER_AXUTILITY_GEO_FORWARD 1
+// #define RENDER_AXUTILITY_ETA_FORWARD 0
+// #define RENDER_AXUTILITY_ETAGEO_FORWARD 0
+#define GEO_OFFSET 0
+// #define ETA_OFFSET 1
+// #define ETAGEO_OFFSET 2
+
+// Spherical harmonics coefficients
+__device__ const float SH_C0 = 0.28209479177387814f;
+__device__ const float SH_C1 = 0.4886025119029199f;
+__device__ const float SH_C2[] = {
+	1.0925484305920792f,
+	-1.0925484305920792f,
+	0.31539156525252005f,
+	-1.0925484305920792f,
+	0.5462742152960396f
+};
+__device__ const float SH_C3[] = {
+	-0.5900435899266435f,
+	2.890611442640554f,
+	-0.4570457994644658f,
+	0.3731763325901154f,
+	-0.4570457994644658f,
+	1.445305721320277f,
+	-0.5900435899266435f
+};
+
+__forceinline__ __device__ float ndc2Pix(float v, int S)
+{
+	return ((v + 1.0) * S - 1.0) * 0.5;   // -1.0 is used to compensate for half pixel
+}
+
+__forceinline__ __device__ void getRect(const float2 p, int max_radius, uint2& rect_min, uint2& rect_max, dim3 grid)
+{
+	rect_min = {
+		min(grid.x, max((int)0, (int)((p.x - max_radius) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y - max_radius) / BLOCK_Y)))
+	};
+	rect_max = {
+		min(grid.x, max((int)0, (int)((p.x + max_radius + BLOCK_X - 1) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y + max_radius + BLOCK_Y - 1) / BLOCK_Y)))
+	};
+}
+
+__forceinline__ __device__ float3 transformPoint4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float4 transformPoint4x4(const float3& p, const float* matrix)
+{
+	float4 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+		matrix[3] * p.x + matrix[7] * p.y + matrix[11] * p.z + matrix[15]
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z,
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z,
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3Transpose(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[1] * p.y + matrix[2] * p.z,
+		matrix[4] * p.x + matrix[5] * p.y + matrix[6] * p.z,
+		matrix[8] * p.x + matrix[9] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float dnormvdz(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+	float dnormvdz = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdz;
+}
+
+__forceinline__ __device__ float3 dnormvdv(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float3 dnormvdv;
+	dnormvdv.x = ((+sum2 - v.x * v.x) * dv.x - v.y * v.x * dv.y - v.z * v.x * dv.z) * invsum32;
+	dnormvdv.y = (-v.x * v.y * dv.x + (sum2 - v.y * v.y) * dv.y - v.z * v.y * dv.z) * invsum32;
+	dnormvdv.z = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float4 dnormvdv(float4 v, float4 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float4 vdv = { v.x * dv.x, v.y * dv.y, v.z * dv.z, v.w * dv.w };
+	float vdv_sum = vdv.x + vdv.y + vdv.z + vdv.w;
+	float4 dnormvdv;
+	dnormvdv.x = ((sum2 - v.x * v.x) * dv.x - v.x * (vdv_sum - vdv.x)) * invsum32;
+	dnormvdv.y = ((sum2 - v.y * v.y) * dv.y - v.y * (vdv_sum - vdv.y)) * invsum32;
+	dnormvdv.z = ((sum2 - v.z * v.z) * dv.z - v.z * (vdv_sum - vdv.z)) * invsum32;
+	dnormvdv.w = ((sum2 - v.w * v.w) * dv.w - v.w * (vdv_sum - vdv.w)) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float sigmoid(float x)
+{
+	return 1.0f / (1.0f + expf(-x));
+}
+
+__forceinline__ __device__ bool in_frustum(int idx,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool prefiltered,
+	float3& p_view)
+{
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// Bring points to screen space
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+	p_view = transformPoint4x3(p_orig, viewmatrix);
+
+	if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	{
+		if (prefiltered)
+		{
+			printf("Point is filtered although prefiltered is set. This shouldn't happen!");
+			__trap();
+		}
+		return false;
+	}
+	return true;
+}
+
+#define CHECK_CUDA(A, debug) \
+A; if(debug) { \
+auto ret = cudaDeviceSynchronize(); \
+if (ret != cudaSuccess) { \
+std::cerr << "\n[CUDA ERROR] in " << __FILE__ << "\nLine " << __LINE__ << ": " << cudaGetErrorString(ret); \
+throw std::runtime_error(cudaGetErrorString(ret)); \
+} \
+}
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/backward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/backward.cu
@@ -1,0 +1,548 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "backward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Backward version of INVERSE 2D covariance matrix computation
+// (due to length launched as separate kernel before other 
+// backward steps contained in preprocess)
+__global__ void computeCov2DCUDA(int P,
+	const float3* means,
+	const int* radii,
+	const float* cov3Ds,
+	const float h_x, float h_y,
+	const float tan_fovx, float tan_fovy,
+	const float* view_matrix,
+	const float* dL_dconics,
+	const float* dL_detas,
+	float3* dL_dmeans,
+	float* dL_dcov,
+	const int mode)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	// Reading location of 3D covariance for this Gaussian
+	const float* cov3D = cov3Ds + 6 * idx;
+
+	// Fetch gradients, recompute 2D covariance and relevant 
+	// intermediate forward results needed in the backward.
+	float3 mean = means[idx];
+	float3 dL_dconic = { dL_dconics[4 * idx], dL_dconics[4 * idx + 1], dL_dconics[4 * idx + 3] };
+	float dL_deta = dL_detas[idx]; 
+	float3 t = transformPoint4x3(mean, view_matrix);
+
+	glm::mat3 J;
+	float x_grad_mul, y_grad_mul;
+	if (mode == 0){  // parallel mode
+		const float limx = 1.3f;
+		const float limy = 1.3f;
+		t.x = min(limx, max(-limx, t.x));
+		t.y = min(limx, max(-limx, t.y));
+		
+		x_grad_mul = t.x < -limx || t.x > limx ? 0 : 1;
+		y_grad_mul = t.y < -limy || t.y > limy ? 0 : 1;
+
+		J = glm::mat3(
+		h_x, 0.0f, 0.0f,
+		0.0f, h_y, 0.0f,
+		0, 0, 1.0f);
+	}
+	else  // cone beam
+	{
+		const float limx = 1.3f * tan_fovx;
+		const float limy = 1.3f * tan_fovy;
+		const float txtz = t.x / t.z;
+		const float tytz = t.y / t.z;
+		t.x = min(limx, max(-limx, txtz)) * t.z;
+		t.y = min(limy, max(-limy, tytz)) * t.z;
+		
+		x_grad_mul = txtz < -limx || txtz > limx ? 0 : 1;
+		y_grad_mul = tytz < -limy || tytz > limy ? 0 : 1;
+
+		const float l = sqrt(t.x * t.x +  t.y * t.y + t.z * t.z);
+		J = glm::mat3(
+			h_x / t.z, 0.0f, -(h_x * t.x) / (t.z * t.z),
+			0.0f, h_y / t.z, -(h_y * t.y) / (t.z * t.z),
+			t.x / l, t.y / l, t.z / l);
+	}
+
+	glm::mat3 W = glm::mat3(
+		view_matrix[0], view_matrix[4], view_matrix[8],
+		view_matrix[1], view_matrix[5], view_matrix[9],
+		view_matrix[2], view_matrix[6], view_matrix[10]);
+
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+
+	glm::mat3 M = W * J;
+
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+
+	// Use helper variables for 2D covariance entries. More compact.
+	float hata = cov[0][0] += 0.0f;
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1] += 0.0f;
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+
+	float dL_dhata = 0, dL_dhatb = 0, dL_dhatc = 0, dL_dhatd = 0, dL_dhate = 0, dL_dhatf = 0;
+	float denom = hata * hatd - hatb * hatb;
+	float denom2inv = 1.0f / ((denom * denom) + 0.0000001f);
+	float diamond = hata * hatd - hatb * hatb;
+
+	// eta part gradient
+	float circ = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	float eta_square = 2 * M_PI * circ / diamond;
+	float eta = 0.0f;
+	if (eta_square > 0.0f){
+		eta = sqrt(2 * M_PI * circ / diamond);
+	}
+	float pi_eta= M_PI / (eta + 0.0000001f);
+	float circ_diamond = circ / diamond;
+
+	if (denom2inv != 0.0f && eta != 0.0f)
+	{
+		// exp(*) part gradient
+		dL_dhata = denom2inv * (-hatd * hatd * dL_dconic.x + hatb * hatd * dL_dconic.y + (denom - hata * hatd) * dL_dconic.z);  // We remove 2 here because in render we do not *0.5
+		dL_dhatd = denom2inv * (-hata * hata * dL_dconic.z + hata * hatb * dL_dconic.y + (denom - hata * hatd) * dL_dconic.x);  // We remove 2 here because in render we do not *0.5
+		dL_dhatb = denom2inv * (2 * hatb * hatd * dL_dconic.x - (denom + 2 * hatb * hatb) * dL_dconic.y + 2 * hata * hatb * dL_dconic.z);
+
+		dL_dhata += pi_eta * ((hatd * hatf - hate * hate) / diamond -  hatd * circ_diamond / diamond) * dL_deta;
+		dL_dhatb += pi_eta * ((2 * hatc * hate - 2 * hatf * hatb) / diamond + 2 * hatb * circ_diamond / diamond) * dL_deta;
+		dL_dhatc += pi_eta * ((2 * hatb * hate - 2 * hatd * hatc) / diamond) * dL_deta;
+		dL_dhatd += pi_eta * ((hata * hatf - hatc * hatc) / diamond -  hata *circ_diamond / diamond) * dL_deta;
+		dL_dhate += pi_eta * ((2 * hatb * hatc - 2 * hata * hate) / diamond) * dL_deta;
+		dL_dhatf += pi_eta * ((hata * hatd - hatb * hatb) / diamond) * dL_deta;
+
+		// Gradients of loss L w.r.t. each 3D covariance matrix (Vrk) entry
+		// dL_da
+		dL_dcov[6 * idx + 0] += M[0][0]*M[0][0]*dL_dhata + M[0][0]*M[1][0]*dL_dhatb + M[0][0]*M[2][0]*dL_dhatc + M[1][0]*M[1][0]*dL_dhatd + M[1][0]*M[2][0]*dL_dhate + M[2][0]*M[2][0]*dL_dhatf;
+		// dL_dd
+		dL_dcov[6 * idx + 3] += M[0][1]*M[0][1]*dL_dhata + M[0][1]*M[1][1]*dL_dhatb + M[0][1]*M[2][1]*dL_dhatc + M[1][1]*M[1][1]*dL_dhatd + M[1][1]*M[2][1]*dL_dhate + M[2][1]*M[2][1]*dL_dhatf;
+		// dL_df
+		dL_dcov[6 * idx + 5] += M[0][2]*M[0][2]*dL_dhata + M[0][2]*M[1][2]*dL_dhatb + M[0][2]*M[2][2]*dL_dhatc + M[1][2]*M[1][2]*dL_dhatd + M[1][2]*M[2][2]*dL_dhate + M[2][2]*M[2][2]*dL_dhatf;
+		
+		// dL_db
+		dL_dcov[6 * idx + 1] += 2*M[0][0]*M[0][1]*dL_dhata + (M[0][1]*M[1][0]+M[0][0]*M[1][1])*dL_dhatb + (M[0][1]*M[2][0]+M[0][0]*M[2][1])*dL_dhatc + 2*M[1][0]*M[1][1]*dL_dhatd + (M[1][1]*M[2][0]+M[1][0]*M[2][1])*dL_dhate + 2*M[2][0]*M[2][1]*dL_dhatf;
+		// dL_dc
+		dL_dcov[6 * idx + 2] += 2*M[0][0]*M[0][2]*dL_dhata + (M[0][2]*M[1][0]+M[0][0]*M[1][2])*dL_dhatb + (M[0][2]*M[2][0]+M[0][0]*M[2][2])*dL_dhatc + 2*M[1][0]*M[1][2]*dL_dhatd + (M[1][2]*M[2][0]+M[1][0]*M[2][2])*dL_dhate + 2*M[2][0]*M[2][2]*dL_dhatf;
+		// dL_de
+		dL_dcov[6 * idx + 4] += 2*M[0][1]*M[0][2]*dL_dhata + (M[0][2]*M[1][1]+M[0][1]*M[1][2])*dL_dhatb + (M[0][2]*M[2][1]+M[0][1]*M[2][2])*dL_dhatc + 2*M[1][1]*M[1][2]*dL_dhatd + (M[1][2]*M[2][1]+M[1][1]*M[2][2])*dL_dhate + 2*M[2][1]*M[2][2]*dL_dhatf;
+	}
+	else
+	{
+		for (int i = 0; i < 6; i++)
+			dL_dcov[6 * idx + i] = 0;
+	}
+
+	if (mode == 1){
+		// Gradients of loss w.r.t. M
+		// cov2D = transpose(M) * transpose(Vrk) * M;
+
+		float a = cov3D[0];
+		float b = cov3D[1];
+		float c = cov3D[2];
+		float d = cov3D[3];
+		float e = cov3D[4];
+		float f = cov3D[5];
+
+		float dL_dM00 = 2*(M[0][0]*a+M[0][1]*b + M[0][2]*c)*dL_dhata + (M[1][0]*a+M[1][1]*b+M[1][2]*c)*dL_dhatb + (M[2][0]*a+M[2][1]*b+M[2][2]*c)*dL_dhatc;
+		float dL_dM01 = 2*(M[0][0]*b+M[0][1]*d + M[0][2]*e)*dL_dhata + (M[1][0]*b+M[1][1]*d+M[1][2]*e)*dL_dhatb + (M[2][0]*b+M[2][1]*d+M[2][2]*e)*dL_dhatc;
+		float dL_dM02 = 2*(M[0][0]*c+M[0][1]*e + M[0][2]*f)*dL_dhata + (M[1][0]*c+M[1][1]*e+M[1][2]*f)*dL_dhatb + (M[2][0]*c+M[2][1]*e+M[2][2]*f)*dL_dhatc;
+
+		float dL_dM10 = (M[0][0]*a+M[0][1]*b+M[0][2]*c)*dL_dhatb + 2*(M[1][0]*a+M[1][1]*b+M[1][2]*c)*dL_dhatd + (M[2][0]*a+M[2][1]*b+M[2][2]*c)*dL_dhate;
+		float dL_dM11 = (M[0][0]*b+M[0][1]*d+M[0][2]*e)*dL_dhatb + 2*(M[1][0]*b+M[1][1]*d+M[1][2]*e)*dL_dhatd + (M[2][0]*b+M[2][1]*d+M[2][2]*e)*dL_dhate;
+		float dL_dM12 = (M[0][0]*c+M[0][1]*e+M[0][2]*f)*dL_dhatb + 2*(M[1][0]*c+M[1][1]*e+M[1][2]*f)*dL_dhatd + (M[2][0]*c+M[2][1]*e+M[2][2]*f)*dL_dhate;
+
+		float dL_dM20 = (M[0][0]*a+M[0][1]*b+M[0][2]*c)*dL_dhatc + (M[1][0]*a+M[1][1]*b+M[1][2]*c)*dL_dhate + 2*(M[2][0]*a+M[2][1]*b+M[2][2]*c)*dL_dhatf;
+		float dL_dM21 = (M[0][0]*b+M[0][1]*d+M[0][2]*e)*dL_dhatc + (M[1][0]*b+M[1][1]*d+M[1][2]*e)*dL_dhate + 2*(M[2][0]*b+M[2][1]*d+M[2][2]*e)*dL_dhatf;
+		float dL_dM22 = (M[0][0]*c+M[0][1]*e+M[0][2]*f)*dL_dhatc + (M[1][0]*c+M[1][1]*e+M[1][2]*f)*dL_dhate + 2*(M[2][0]*c+M[2][1]*e+M[2][2]*f)*dL_dhatf;
+
+		float dL_dJ00 = W[0][0]*dL_dM00 + W[0][1]*dL_dM01 + W[0][2]*dL_dM02;
+		float dL_dJ02 = W[2][0]*dL_dM00 + W[2][1]*dL_dM01 + W[2][2]*dL_dM02;
+		float dL_dJ11 = W[1][0]*dL_dM10 + W[1][1]*dL_dM11 + W[1][2]*dL_dM12;
+		float dL_dJ12 = W[2][0]*dL_dM10 + W[2][1]*dL_dM11 + W[2][2]*dL_dM12;
+		float dL_dJ20 = W[0][0]*dL_dM20 + W[0][1]*dL_dM21 + W[0][2]*dL_dM22;
+		float dL_dJ21 = W[1][0]*dL_dM20 + W[1][1]*dL_dM21 + W[1][2]*dL_dM22;
+		float dL_dJ22 = W[2][0]*dL_dM20 + W[2][1]*dL_dM21 + W[2][2]*dL_dM22;
+
+		float tx = t.x;
+		float ty = t.y;
+		float tz = t.z;
+		float inv_tz = 1.f / tz;
+		float inv_tz2 = inv_tz * inv_tz;
+		float inv_tz3 = inv_tz2 * inv_tz;
+		float circledcirc = sqrt(tx * tx + ty * ty + tz * tz);
+		float inv_circledcirc3 = 1 / (circledcirc * circledcirc * circledcirc);
+		float dL_dtx = x_grad_mul * (-h_x*inv_tz2*dL_dJ02 + (1/circledcirc - tx*tx*inv_circledcirc3)*dL_dJ20 - tx*ty*inv_circledcirc3*dL_dJ21 - tx*tz*inv_circledcirc3*dL_dJ22);
+		float dL_dty = y_grad_mul * (-h_y*inv_tz2*dL_dJ12 - tx*ty*inv_circledcirc3*dL_dJ20 + (1/circledcirc - ty*ty*inv_circledcirc3)*dL_dJ21 - ty*tz*inv_circledcirc3*dL_dJ22);
+		float dL_dtz = -h_x*inv_tz2*dL_dJ00 + 2*h_x*tx*inv_tz3*dL_dJ02 - h_y*inv_tz2*dL_dJ11 + 2*h_y*ty*inv_tz3*dL_dJ12 - tx*tz*inv_circledcirc3*dL_dJ20 - ty*tz*inv_circledcirc3*dL_dJ21 + (1/circledcirc-tz*tz*inv_circledcirc3)*dL_dJ22;
+
+		float3 dL_dmean = transformVec4x3Transpose({ dL_dtx, dL_dty, dL_dtz }, view_matrix);
+
+		// Gradients of loss w.r.t. Gaussian means, but only the portion 
+		// that is caused because the mean affects the covariance matrix.
+		// Additional mean gradient is accumulated in BACKWARD::preprocess.
+		dL_dmeans[idx] = dL_dmean;
+
+	}
+}
+
+// Backward pass for the conversion of scale and rotation to a 
+// 3D covariance matrix for each Gaussian. 
+__device__ void computeCov3D(int idx, const glm::vec3 scale, float mod, const glm::vec4 rot, const float* dL_dcov3Ds, glm::vec3* dL_dscales, glm::vec4* dL_drots)
+{
+	// Recompute (intermediate) results for the 3D covariance computation.
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 S = glm::mat3(1.0f);
+
+	glm::vec3 s = mod * scale;
+	S[0][0] = s.x;
+	S[1][1] = s.y;
+	S[2][2] = s.z;
+
+	glm::mat3 M = S * R;
+
+	const float* dL_dcov3D = dL_dcov3Ds + 6 * idx;
+
+	glm::vec3 dunc(dL_dcov3D[0], dL_dcov3D[3], dL_dcov3D[5]);
+	glm::vec3 ounc = 0.5f * glm::vec3(dL_dcov3D[1], dL_dcov3D[2], dL_dcov3D[4]);
+
+	// Convert per-element covariance loss gradients to matrix form
+	glm::mat3 dL_dSigma = glm::mat3(
+		dL_dcov3D[0], 0.5f * dL_dcov3D[1], 0.5f * dL_dcov3D[2],
+		0.5f * dL_dcov3D[1], dL_dcov3D[3], 0.5f * dL_dcov3D[4],
+		0.5f * dL_dcov3D[2], 0.5f * dL_dcov3D[4], dL_dcov3D[5]
+	);
+
+	// Compute loss gradient w.r.t. matrix M
+	// dSigma_dM = 2 * M
+	glm::mat3 dL_dM = 2.0f * M * dL_dSigma;
+
+	glm::mat3 Rt = glm::transpose(R);
+	glm::mat3 dL_dMt = glm::transpose(dL_dM);
+
+	// Gradients of loss w.r.t. scale
+	glm::vec3* dL_dscale = dL_dscales + idx;
+	dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
+	dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
+	dL_dscale->z = glm::dot(Rt[2], dL_dMt[2]);
+
+	dL_dMt[0] *= s.x;
+	dL_dMt[1] *= s.y;
+	dL_dMt[2] *= s.z;
+
+	// Gradients of loss w.r.t. normalized quaternion
+	glm::vec4 dL_dq;
+	dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2] - dL_dMt[2][1]);
+	dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2] - dL_dMt[2][1]) - 4 * x * (dL_dMt[2][2] + dL_dMt[1][1]);
+	dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * y * (dL_dMt[2][2] + dL_dMt[0][0]);
+	dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
+
+	// Gradients of loss w.r.t. unnormalized quaternion
+	float4* dL_drot = (float4*)(dL_drots + idx);
+	*dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w };//dnormvdv(float4{ rot.x, rot.y, rot.z, rot.w }, float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w });
+}
+
+// Backward pass of the preprocessing steps, except
+// for the covariance computation and inversion
+// (those are handled by a previous kernel call)
+template<int C>
+__global__ void preprocessCUDA(
+	int P,
+	const float3* means,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* proj,
+	const glm::vec3* campos,
+	const float3* dL_dmean2D,
+	glm::vec3* dL_dmeans,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	float3 m = means[idx];
+
+	// Taking care of gradients from the screenspace points
+	float4 m_hom = transformPoint4x4(m, proj);
+	float m_w = 1.0f / (m_hom.w + 0.0000001f);
+
+	// Compute loss gradient w.r.t. 3D means due to gradients of 2D means
+	// from rendering procedure
+	glm::vec3 dL_dmean;
+	float mul1 = (proj[0] * m.x + proj[4] * m.y + proj[8] * m.z + proj[12]) * m_w * m_w;
+	float mul2 = (proj[1] * m.x + proj[5] * m.y + proj[9] * m.z + proj[13]) * m_w * m_w;
+	dL_dmean.x = (proj[0] * m_w - proj[3] * mul1) * dL_dmean2D[idx].x + (proj[1] * m_w - proj[3] * mul2) * dL_dmean2D[idx].y;
+	dL_dmean.y = (proj[4] * m_w - proj[7] * mul1) * dL_dmean2D[idx].x + (proj[5] * m_w - proj[7] * mul2) * dL_dmean2D[idx].y;
+	dL_dmean.z = (proj[8] * m_w - proj[11] * mul1) * dL_dmean2D[idx].x + (proj[9] * m_w - proj[11] * mul2) * dL_dmean2D[idx].y;
+
+	// That's the second part of the mean gradient. Previous computation
+	// of cov2D and following SH conversion also affects it.
+	dL_dmeans[idx] += dL_dmean;
+
+	// Compute gradient updates due to computing covariance from scale/rotation
+	if (scales)
+		computeCov3D(idx, scales[idx], scale_modifier, rotations[idx], dL_dcov3D, dL_dscale, dL_drot);
+}
+
+// Backward version of the rendering procedure.
+template <uint32_t C>
+__global__ void __launch_bounds__(BLOCK_X * BLOCK_Y)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	int W, int H,
+	const float2* __restrict__ points_xy_image,
+	const float4* __restrict__ conic_opacity,
+	const float* __restrict__ etas,
+	const uint32_t* __restrict__ n_contrib,
+	const float* __restrict__ dL_dpixels,
+	float3* __restrict__ dL_dmean2D,
+	float4* __restrict__ dL_dconic2D,
+	float* __restrict__ dL_dopacity,
+	float* __restrict__ dL_deta)
+{	
+	// We rasterize again. Compute necessary block info.
+	auto block = cg::this_thread_block();
+	const uint32_t horizontal_blocks = (W + BLOCK_X - 1) / BLOCK_X;
+	const uint2 pix_min = { block.group_index().x * BLOCK_X, block.group_index().y * BLOCK_Y };
+	const uint2 pix_max = { min(pix_min.x + BLOCK_X, W), min(pix_min.y + BLOCK_Y , H) };
+	const uint2 pix = { pix_min.x + block.thread_index().x, pix_min.y + block.thread_index().y };
+	const uint32_t pix_id = W * pix.y + pix.x;
+	float2 pixf = { (float)pix.x, (float)pix.y};
+
+	const bool inside = pix.x < W&& pix.y < H;
+	const uint2 range = ranges[block.group_index().y * horizontal_blocks + block.group_index().x];
+
+	const int rounds = ((range.y - range.x + BLOCK_SIZE - 1) / BLOCK_SIZE);
+
+	bool done = !inside;
+	int toDo = range.y - range.x;
+
+	__shared__ int collected_id[BLOCK_SIZE];
+	__shared__ float2 collected_xy[BLOCK_SIZE];
+	__shared__ float4 collected_conic_opacity[BLOCK_SIZE];
+	__shared__ float collected_eta[BLOCK_SIZE];
+
+	// We start from the back. The ID of the last contributing
+	// Gaussian is known from each pixel from the forward.
+	uint32_t contributor = toDo;
+	const int last_contributor = inside ? n_contrib[pix_id] : 0;
+    
+	float dL_dpixel[C];
+	if (inside)
+		for (int i = 0; i < C; i++)
+			dL_dpixel[i] = dL_dpixels[i * H * W + pix_id];
+
+	// Gradient of pixel coordinate w.r.t. normalized 
+	// screen-space viewport corrdinates (-1 to 1)
+	const float ddelx_dx = 0.5 * W;
+	const float ddely_dy = 0.5 * H;
+
+	// Traverse all Gaussians
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK_SIZE)
+	{
+		// Load auxiliary data into shared memory, start in the BACK
+		// and load them in revers order.
+		block.sync();
+		const int progress = i * BLOCK_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			const int coll_id = point_list[range.y - progress - 1];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xy[block.thread_rank()] = points_xy_image[coll_id];
+			collected_conic_opacity[block.thread_rank()] = conic_opacity[coll_id];
+			collected_eta[block.thread_rank()] = etas[coll_id];
+		}
+		block.sync();
+
+		// Iterate over Gaussians
+		for (int j = 0; !done && j < min(BLOCK_SIZE, toDo); j++)
+		{
+			// Keep track of current Gaussian ID. Skip, if this one
+			// is behind the last contributor for this pixel.
+			contributor--;
+			if (contributor >= last_contributor)
+				continue;
+
+			// Compute blending values, as before.
+			const float2 xy = collected_xy[j];
+			const float2 d = { xy.x - pixf.x, xy.y - pixf.y };
+			const float4 con_o = collected_conic_opacity[j];
+			float eta = collected_eta[j];
+			const float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			const float alpha = con_o.w * eta * G;
+			if (alpha < 0.00001f)
+				continue;
+
+			// Propagate gradients to per-Gaussian colors and keep
+			// gradients w.r.t. alpha (blending factor for a Gaussian/pixel
+			// pair).
+			// Since we are simple sum, dchannel_dalpha = 1.0
+			float dL_dalpha = 0.0f;
+			const int global_id = collected_id[j];
+			for (int ch = 0; ch < C; ch++)
+			{
+				const float dL_dchannel = dL_dpixel[ch];
+				dL_dalpha += 1.f * dL_dchannel;
+			}
+
+			// Helpful reusable temporary variables
+			const float dL_dG = con_o.w * eta * dL_dalpha;
+			const float gdx = G * d.x;
+			const float gdy = G * d.y;
+			const float dG_ddelx = -gdx * con_o.x - gdy * con_o.y;
+			const float dG_ddely = -gdy * con_o.z - gdx * con_o.y;
+
+			// Update gradients w.r.t. 2D mean position of the Gaussian
+			const float dL_dx = dL_dG * dG_ddelx * ddelx_dx;
+			const float dL_dy = dL_dG * dG_ddely * ddely_dy;			
+			atomicAdd(&dL_dmean2D[global_id].x, dL_dG * dG_ddelx * ddelx_dx); // ddelx_dx is used to compensate ndc2pix
+			atomicAdd(&dL_dmean2D[global_id].y, dL_dG * dG_ddely * ddely_dy); // ddelx_dx is used to compensate ndc2pix
+			atomicAdd(&dL_dmean2D[global_id].z, abs(dL_dx) + abs(dL_dy)); 
+
+			// Update gradients w.r.t. 2D covariance (2x2 matrix, symmetric)
+			atomicAdd(&dL_dconic2D[global_id].x, -0.5f * gdx * d.x * dL_dG);
+			atomicAdd(&dL_dconic2D[global_id].y, -1.0f * gdx * d.y * dL_dG); // gs code is 0.5f, which is futher compensated in computecov2D
+			atomicAdd(&dL_dconic2D[global_id].w, -0.5f * gdy * d.y * dL_dG);
+
+			// Update gradients w.r.t. opacity of the Gaussian
+			atomicAdd(&(dL_dopacity[global_id]), eta * G * dL_dalpha);
+			atomicAdd(&(dL_deta[global_id]), con_o.w * G * dL_dalpha);
+			
+		}
+	}
+}
+
+
+void BACKWARD::preprocess(
+	int P,
+	const float3* means3D,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* cov3Ds,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float focal_x, float focal_y,
+	const float tan_fovx, float tan_fovy,
+	const glm::vec3* campos,
+	const float3* dL_dmean2D,
+	const float* dL_dconic,
+	const float* dL_deta,
+	glm::vec3* dL_dmean3D,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot,
+	const int mode)
+{
+	// Propagate gradients for the path of 2D conic matrix computation. 
+	// Somewhat long, thus it is its own kernel rather than being part of 
+	// "preprocess". When done, loss gradient w.r.t. 3D means has been
+	// modified and gradient w.r.t. 3D covariance matrix has been computed.	
+	computeCov2DCUDA << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		radii,
+		cov3Ds,
+		focal_x,
+		focal_y,
+		tan_fovx,
+		tan_fovy,
+		viewmatrix,
+		dL_dconic,
+		dL_deta,
+		(float3*)dL_dmean3D,
+		dL_dcov3D,
+		mode);
+
+	// Propagate gradients for remaining steps: finish 3D mean gradients,
+	// propagate color gradients to SH (if desireD), propagate 3D covariance
+	// matrix gradients to scale and rotation.
+	preprocessCUDA<NUM_CHANNELS> << < (P + 255) / 256, 256 >> > (
+		P,
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		projmatrix,
+		campos,
+		(float3*)dL_dmean2D,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		dL_dscale,
+		dL_drot);
+}
+
+void BACKWARD::render(
+	const dim3 grid, const dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	int W, int H,
+	const float2* means2D,
+	const float4* conic_opacity,
+	const float* etas,
+	const uint32_t* n_contrib,
+	const float* dL_dpixels,
+	float3* dL_dmean2D,
+	float4* dL_dconic2D,
+	float* dL_dopacity,
+	float* dL_deta
+	)
+{
+	renderCUDA<NUM_CHANNELS> << <grid, block >> >(
+		ranges,
+		point_list,
+		W, H,
+		means2D,
+		conic_opacity,
+		etas,
+		n_contrib,
+		dL_dpixels,
+		dL_dmean2D,
+		dL_dconic2D,
+		dL_dopacity,
+		dL_deta
+		);
+}
+

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/backward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/backward.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_BACKWARD_H_INCLUDED
+#define CUDA_RASTERIZER_BACKWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace BACKWARD
+{
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		int W, int H,
+		const float2* means2D,
+		const float4* conic_opacity,
+		const float* etas,
+		const uint32_t* n_contrib,
+		const float* dL_dpixels,
+		float3* dL_dmean2D,
+		float4* dL_dconic2D,
+		float* dL_dopacity,
+		float* dL_deta);
+
+	void preprocess(
+		int P,
+		const float3* means,
+		const int* radii,
+		const glm::vec3* scales,
+		const glm::vec4* rotations,
+		const float scale_modifier,
+		const float* cov3Ds,
+		const float* view,
+		const float* proj,
+		const float focal_x, float focal_y,
+		const float tan_fovx, float tan_fovy,
+		const glm::vec3* campos,
+		const float3* dL_dmean2D,
+		const float* dL_dconics,
+		const float* dL_deta,
+		glm::vec3* dL_dmeans,
+		float* dL_dcov3D,
+		glm::vec3* dL_dscale,
+		glm::vec4* dL_drot,
+		const int mode);
+}
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/config.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/config.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_CONFIG_H_INCLUDED
+#define CUDA_RASTERIZER_CONFIG_H_INCLUDED
+
+#define NUM_CHANNELS 1
+#define NUM_OTHERS 1
+#define BLOCK_X 16
+#define BLOCK_Y 16
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/forward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/forward.cu
@@ -1,0 +1,456 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+#include <stdio.h> // for debug
+#include "forward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Forward version of 2D covariance matrix computation
+// Section 6.2 EWA Volume Resampling Filter
+__device__ float4 computeCov2D(const float3& mean, float focal_x, float focal_y, float tan_fovx, float tan_fovy, const float* cov3D, const float* viewmatrix, const int mode)
+{
+	// The following models the steps outlined by equations 29
+	// and 31 in "EWA Splatting" (Zwicker et al., 2002). 
+	// Additionally considers aspect / scaling of viewport.
+	// Transposes used to account for row-/column-major conventions.
+
+	// This is the transformation from Source (world) to view (camera)
+	float3 t = transformPoint4x3(mean, viewmatrix);
+    glm::mat3 J;
+	if (mode == 0){  // parallel beam
+		const float limx = 1.3f;
+		const float limy = 1.3f;
+		t.x = min(limx, max(-limx, t.x));
+		t.y = min(limx, max(-limx, t.y));
+
+		// J is eye
+		J = glm::mat3(
+		focal_x, 0.0f, 0.0f,
+		0.0f, focal_y, 0.0f,
+		0.0f, 0.0f, 1.0f);
+	}
+	else  // cone beam
+	{	
+		const float limx = 1.3f * tan_fovx;
+		const float limy = 1.3f * tan_fovy;
+		const float txtz = t.x / t.z;
+		const float tytz = t.y / t.z;
+		// t = Phi^-1(x), eq(26)
+		t.x = min(limx, max(-limx, txtz)) * t.z;
+		t.y = min(limy, max(-limy, tytz)) * t.z;
+		// Jacobian of Affine approximation of projection transformation
+		// eq(29)
+		const float l = sqrt(t.x * t.x +  t.y * t.y + t.z * t.z);
+		J = glm::mat3(
+			focal_x / t.z, 0.0f, -(focal_x * t.x) / (t.z * t.z),
+			0.0f, focal_y / t.z, -(focal_y * t.y) / (t.z * t.z),
+			t.x / l, t.y / l, t.z / l);
+	}
+	
+	// Viewing transformation
+	glm::mat3 W = glm::mat3(
+		viewmatrix[0], viewmatrix[4], viewmatrix[8],
+		viewmatrix[1], viewmatrix[5], viewmatrix[9],
+		viewmatrix[2], viewmatrix[6], viewmatrix[10]);
+	
+	glm::mat3 M = W * J;
+    
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+    
+	// J W Sigma W^M J^M
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+
+	// Apply low-pass filter: every Gaussian should be at least
+	// one pixel wide/high. Discard 3rd row and column.
+	// why 0.3f? 
+	cov[0][0] += 0.0f;
+	cov[1][1] += 0.0f;
+
+	// Compute eta
+	float hata = cov[0][0];
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1];
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+	float diamond = hata * hatd - hatb * hatb;
+	float circ = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	float eta_square = 2 * M_PI * circ / diamond;
+	float eta = 0.0f;
+	if (eta_square > 0.0f){
+		eta = sqrt(2 * M_PI * circ / diamond);
+	}
+
+	// printf("eta: %f\n", eta);
+	// printf("circ: %f\n", circ);
+	// printf("diamond: %f\n", diamond);
+
+	// printf("cov:\n");
+	// printf("%f\t%f\t%f\n", cov[0][0], cov[0][1], cov[0][2]);
+	// printf("%f\t%f\t%f\n", cov[1][0], cov[1][1], cov[1][2]);
+	// printf("%f\t%f\t%f\n", cov[2][0], cov[2][1], cov[2][2]);
+
+
+	return { float(cov[0][0]), float(cov[0][1]), float(cov[1][1]), float(eta) };
+}
+
+// Forward method for converting scale and rotation properties of each
+// Gaussian to a 3D covariance matrix in world space. Also takes care
+// of quaternion normalization.
+__device__ void computeCov3D(const glm::vec3 scale, float mod, const glm::vec4 rot, float* cov3D)
+{
+	// Create scaling matrix
+	glm::mat3 S = glm::mat3(1.0f);
+	S[0][0] = mod * scale.x;
+	S[1][1] = mod * scale.y;
+	S[2][2] = mod * scale.z;
+
+	// Normalize quaternion to get valid rotation
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	// Compute rotation matrix from quaternion
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 M = S * R;
+
+	// Compute 3D world covariance matrix Sigma
+	glm::mat3 Sigma = glm::transpose(M) * M;
+
+	// Covariance is symmetric, only store upper right
+	cov3D[0] = Sigma[0][0];  // a
+	cov3D[1] = Sigma[0][1];  // b
+	cov3D[2] = Sigma[0][2];  // c
+	cov3D[3] = Sigma[1][1];  // d
+	cov3D[4] = Sigma[1][2];  // e
+	cov3D[5] = Sigma[2][2];  // f
+}
+
+// Perform initial steps for each Gaussian prior to rasterization.
+template<int C>
+__global__ void preprocessCUDA(int P,
+	const float* orig_points,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const glm::vec3* cam_pos,
+	const int W, int H,
+	const float tan_fovx, float tan_fovy,
+	const float focal_x, float focal_y,
+	int* radii,
+	float2* points_xy_image,
+	float* depths,
+	float* cov3Ds,
+	float4* conic_opacity,
+	float* etas,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered,
+	const int mode
+	)
+{
+	auto idx = cg::this_grid().thread_rank(); //idx
+	if (idx >= P)
+		return;
+
+	// Initialize radius and touched tiles to 0. If this isn't changed,
+	// this Gaussian will not be processed further.
+	radii[idx] = 0;
+	tiles_touched[idx] = 0;
+
+	// Perform near culling, quit if outside.
+	float3 p_view;
+	if (!in_frustum(idx, orig_points, viewmatrix, projmatrix, prefiltered, p_view)) // 在cuda_rasterizer/auxilliary.cu，顺便计算了p_view：在相机坐标系下的点的3D位置
+		return;
+
+	// Transform point by projecting
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+
+	// If 3D covariance matrix is precomputed, use it, otherwise compute
+	// from scaling and rotation parameters. 
+	const float* cov3D;
+	if (cov3D_precomp != nullptr)
+	{
+		cov3D = cov3D_precomp + idx * 6;
+	}
+	else
+	{
+		computeCov3D(scales[idx], scale_modifier, rotations[idx], cov3Ds + idx * 6);
+		cov3D = cov3Ds + idx * 6;
+	}
+
+	// Compute 2D screen-space covariance matrix
+	float4 cov = computeCov2D(p_orig, focal_x, focal_y, tan_fovx, tan_fovy, cov3D, viewmatrix, mode);
+
+	// Invert covariance (EWA algorithm)
+	float det = (cov.x * cov.z - cov.y * cov.y);
+	if (det == 0.0f)
+		return;
+	float det_inv = 1.f / det;
+	float3 conic = { cov.z * det_inv, -cov.y * det_inv, cov.x * det_inv };
+
+	// Compute extent in screen space (by finding eigenvalues of
+	// 2D covariance matrix). Use extent to compute a bounding rectangle
+	// of screen-space tiles that this Gaussian overlaps with. Quit if
+	// rectangle covers 0 tiles. 
+	float mid = 0.5f * (cov.x + cov.z);
+	float lambda1 = mid + sqrt(max(0.1f, mid * mid - det)); 
+	float lambda2 = mid - sqrt(max(0.1f, mid * mid - det));
+	float my_radius = ceil(3.f * sqrt(max(lambda1, lambda2)));
+	float2 point_image = { ndc2Pix(p_proj.x, W), ndc2Pix(p_proj.y, H) };
+	uint2 rect_min, rect_max;
+	getRect(point_image, my_radius, rect_min, rect_max, grid);
+	if ((rect_max.x - rect_min.x) * (rect_max.y - rect_min.y) == 0)
+		return;
+
+	// Store some useful helper data for the next steps.
+	depths[idx] = p_view.z;
+	radii[idx] = my_radius;
+	points_xy_image[idx] = point_image;
+	// Inverse 2D covariance and opacity neatly pack into one float4
+	conic_opacity[idx] = { conic.x, conic.y, conic.z, opacities[idx] };
+	tiles_touched[idx] = (rect_max.y - rect_min.y) * (rect_max.x - rect_min.x);
+	etas[idx] = cov.w;
+}
+
+// Main rasterization method. Collaboratively works on one tile per
+// block, each thread treats one pixel. Alternates between fetching 
+// and rasterizing data.
+template <uint32_t CHANNELS>
+__global__ void __launch_bounds__(BLOCK_X * BLOCK_Y)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	int W, int H,
+	const float2* __restrict__ points_xy_image,
+	const float4* __restrict__ conic_opacity,
+	const float* __restrict__ etas,
+	uint32_t* __restrict__ n_contrib,
+	float* __restrict__ out_color,
+	float* __restrict__ out_others)
+{
+	// Identify current tile and associated min/max pixel range.
+	auto block = cg::this_thread_block();
+	uint32_t horizontal_blocks = (W + BLOCK_X - 1) / BLOCK_X;
+	uint2 pix_min = { block.group_index().x * BLOCK_X, block.group_index().y * BLOCK_Y };
+	uint2 pix_max = { min(pix_min.x + BLOCK_X, W), min(pix_min.y + BLOCK_Y , H) };
+	uint2 pix = { pix_min.x + block.thread_index().x, pix_min.y + block.thread_index().y };
+	uint32_t pix_id = W * pix.y + pix.x;
+	float2 pixf = { (float)pix.x, (float)pix.y};
+
+	// Check if this thread is associated with a valid pixel or outside.
+	bool inside = pix.x < W&& pix.y < H;
+	// Done threads can help with fetching, but don't rasterize
+	bool done = !inside;
+
+	// Load start/end range of IDs to process in bit sorted list.
+	uint2 range = ranges[block.group_index().y * horizontal_blocks + block.group_index().x];
+	const int rounds = ((range.y - range.x + BLOCK_SIZE - 1) / BLOCK_SIZE);
+	int toDo = range.y - range.x;
+
+	// Allocate storage for batches of collectively fetched data.
+	__shared__ int collected_id[BLOCK_SIZE];
+	__shared__ float2 collected_xy[BLOCK_SIZE];
+	__shared__ float4 collected_conic_opacity[BLOCK_SIZE];
+	__shared__ float collected_eta[BLOCK_SIZE];
+
+	// Initialize helper variables
+	uint32_t contributor = 0;
+	uint32_t last_contributor = 0;
+	float C[CHANNELS] = { 0 };
+
+	#if RENDER_AXUTILITY_GEO_FORWARD
+		float georender = {0};
+	#endif
+	// #if RENDER_AXUTILITY_ETA_FORWARD
+	// 	float etarender = {0};
+	// #endif
+	// #if RENDER_AXUTILITY_ETAGEO_FORWARD
+	// 	float etageorender = {0};
+	// #endif
+
+	// Iterate over batches until all done or range is complete
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK_SIZE)
+	{
+		// End if entire block votes that it is done rasterizing
+		int num_done = __syncthreads_count(done);
+		if (num_done == BLOCK_SIZE)
+			break;
+
+		// Collectively fetch per-Gaussian data from global to shared
+		int progress = i * BLOCK_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			int coll_id = point_list[range.x + progress];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xy[block.thread_rank()] = points_xy_image[coll_id];
+			collected_conic_opacity[block.thread_rank()] = conic_opacity[coll_id];
+			collected_eta[block.thread_rank()] = etas[coll_id];
+		}
+		block.sync();
+
+		// Iterate over current batch
+		for (int j = 0; !done && j < min(BLOCK_SIZE, toDo); j++)
+		{
+			// Keep track of current position in range
+			contributor++;
+
+			// Resample using conic matrix (cf. "Surface 
+			// Splatting" by Zwicker et al., 2001)
+			float2 xy = collected_xy[j];
+			float2 d = { xy.x - pixf.x, xy.y - pixf.y };
+			float4 con_o = collected_conic_opacity[j];
+			float eta = collected_eta[j];
+			float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			const float etaG = eta * G;
+			#if RENDER_AXUTILITY_GEO_FORWARD
+				georender += G;
+			#endif
+			// #if RENDER_AXUTILITY_ETA_FORWARD
+			// 	etarender += eta;
+			// #endif
+			// #if RENDER_AXUTILITY_ETAGEO_FORWARD
+			// 	etageorender += etaG;
+			// #endif
+			const float alpha = con_o.w * etaG;
+			if (alpha < 0.00001f)
+				continue;
+
+			// Simply add all alphas
+			for (int ch = 0; ch < CHANNELS; ch++)
+				C[ch] += alpha;
+
+
+			// Keep track of last range entry to update this
+			// pixel.
+			last_contributor = contributor;
+		}
+	}
+
+	// All threads that treat valid pixel write out their final
+	// rendering data to the frame and auxiliary buffers.
+	if (inside)
+	{
+		n_contrib[pix_id] = last_contributor;
+		for (int ch = 0; ch < CHANNELS; ch++)
+			out_color[ch * H * W + pix_id] = C[ch];
+		#if RENDER_AXUTILITY_GEO_FORWARD
+			out_others[GEO_OFFSET * H * W + pix_id] = georender;
+		#endif
+		// #if RENDER_AXUTILITY_ETA_FORWARD
+		// 	out_others[ETA_OFFSET * H * W + pix_id] = etarender;
+		// #endif
+		// #if RENDER_AXUTILITY_ETAGEO_FORWARD
+		// 	out_others[ETAGEO_OFFSET * H * W + pix_id] = etageorender;
+		// #endif
+	}
+}
+
+
+void FORWARD::render(
+	const dim3 grid, dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	int W, int H,
+	const float2* means2D,
+	const float4* conic_opacity,
+	const float* etas,
+	uint32_t* n_contrib,
+	float* out_color,
+	float* out_others)
+{
+	renderCUDA<NUM_CHANNELS> << <grid, block >> > (
+		ranges,
+		point_list,
+		W, H,
+		means2D,
+		conic_opacity,
+		etas,
+		n_contrib,
+		out_color,
+		out_others);
+}
+
+
+void FORWARD::preprocess(int P,
+	const float* means3D,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const glm::vec3* cam_pos,
+	const int W, int H,
+	const float focal_x, float focal_y,
+	const float tan_fovx, float tan_fovy,
+	int* radii,
+	float2* means2D,
+	float* depths,
+	float* cov3Ds,
+	float4* conic_opacity,
+	float* etas,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered,
+	const int mode
+	)
+{
+	preprocessCUDA<NUM_CHANNELS> << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		scales,
+		scale_modifier,
+		rotations,
+		opacities,
+		cov3D_precomp,
+		viewmatrix, 
+		projmatrix,
+		cam_pos,
+		W, H,
+		tan_fovx, tan_fovy,
+		focal_x, focal_y,
+		radii,
+		means2D,
+		depths,
+		cov3Ds,
+		conic_opacity,
+		etas,
+		grid,
+		tiles_touched,
+		prefiltered,
+		mode
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/forward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/forward.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_FORWARD_H_INCLUDED
+#define CUDA_RASTERIZER_FORWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace FORWARD
+{
+	// Perform initial steps for each Gaussian prior to rasterization.
+	void preprocess(int P, 
+		const float* orig_points,
+		const glm::vec3* scales,
+		const float scale_modifier,
+		const glm::vec4* rotations,
+		const float* opacities,
+		const float* cov3D_precomp,
+		const float* viewmatrix,
+		const float* projmatrix,
+		const glm::vec3* cam_pos,
+		const int W, int H,
+		const float focal_x, float focal_y,
+		const float tan_fovx, float tan_fovy,
+		int* radii,
+		float2* points_xy_image,
+		float* depths,
+		float* cov3Ds,
+		float4* conic_opacity,
+		float* etas,
+		const dim3 grid,
+		uint32_t* tiles_touched,
+		bool prefiltered,
+		const int mode
+		);
+
+	// Main rasterization method.
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		int W, int H,
+		const float2* points_xy_image,
+		const float4* conic_opacity,
+		const float* etas,
+		uint32_t* n_contrib,
+		float* out_color,
+		float* out_others);
+}
+
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/rasterizer.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/rasterizer.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef CUDA_RASTERIZER_H_INCLUDED
+#define CUDA_RASTERIZER_H_INCLUDED
+
+#include <vector>
+#include <functional>
+
+namespace CudaRasterizer
+{
+    class Rasterizer
+	{
+	public:
+        
+        // Basic Function
+		static void markVisible(
+			int P,
+			float* means3D,
+			float* viewmatrix,
+			float* projmatrix,
+			bool* present);
+		
+		static int forward(
+			std::function<char* (size_t)> geometryBuffer,
+			std::function<char* (size_t)> binningBuffer,
+			std::function<char* (size_t)> imageBuffer,
+			const int P,
+			const int width, int height,
+			const float* means3D,
+			const float* opacities,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const float* viewmatrix,
+			const float* projmatrix,
+			const float* cam_pos,
+			const float tan_fovx, float tan_fovy,
+			const bool prefiltered,
+			const int mode,
+			float* out_color,
+			float* out_others,
+			int* radii = nullptr,
+			bool debug = false);
+
+		static void backward(
+			const int P, int R,
+			const int width, int height,
+			const float* means3D,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const float* viewmatrix,
+			const float* projmatrix,
+			const float* campos,
+			const float tan_fovx, float tan_fovy,
+			const int* radii,
+			char* geom_buffer,
+			char* binning_buffer,
+			char* image_buffer,
+			const float* dL_dpix,
+			float* dL_dmean2D,
+			float* dL_dconic,
+			float* dL_dopacity,
+			float* dL_deta,
+			float* dL_dmean3D,
+			float* dL_dcov3D,
+			float* dL_dscale,
+			float* dL_drot,
+			const int mode,
+			bool debug);
+	};
+
+};
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/rasterizer_impl.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/rasterizer_impl.cu
@@ -1,0 +1,421 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "rasterizer_impl.h"
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+#include "auxiliary.h"
+#include "forward.h"
+#include "backward.h"
+
+// Helper function to find the next-highest bit of the MSB
+// on the CPU.
+uint32_t getHigherMsb(uint32_t n)
+{
+	uint32_t msb = sizeof(n) * 4;
+	uint32_t step = msb;
+	while (step > 1)
+	{
+		step /= 2;
+		if (n >> msb)
+			msb += step;
+		else
+			msb -= step;
+	}
+	if (n >> msb)
+		msb++;
+	return msb;
+}
+
+// Wrapper method to call auxiliary coarse frustum containment test.
+// Mark all Gaussians that pass it.
+__global__ void checkFrustum(int P,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool* present)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	float3 p_view;
+	present[idx] = in_frustum(idx, orig_points, viewmatrix, projmatrix, false, p_view);
+}
+
+// Generates one key/value pair for all Gaussian / tile overlaps. 
+// Run once per Gaussian (1:N mapping).
+__global__ void duplicateWithKeys(
+	int P,
+	const float2* points_xy,
+	const float* depths,
+	const uint32_t* offsets,
+	uint64_t* gaussian_keys_unsorted,
+	uint32_t* gaussian_values_unsorted,
+	int* radii,
+	dim3 grid)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	// Generate no key/value pair for invisible Gaussians
+	if (radii[idx] > 0)
+	{
+		// Find this Gaussian's offset in buffer for writing keys/values.
+		uint32_t off = (idx == 0) ? 0 : offsets[idx - 1];
+		uint2 rect_min, rect_max;
+
+		getRect(points_xy[idx], radii[idx], rect_min, rect_max, grid);
+
+		// For each tile that the bounding rect overlaps, emit a 
+		// key/value pair. The key is |  tile ID  |      depth      |,
+		// and the value is the ID of the Gaussian. Sorting the values 
+		// with this key yields Gaussian IDs in a list, such that they
+		// are first sorted by tile and then by depth. 
+		for (int y = rect_min.y; y < rect_max.y; y++)
+		{
+			for (int x = rect_min.x; x < rect_max.x; x++)
+			{
+				uint64_t key = y * grid.x + x;
+				key <<= 32;
+				key |= *((uint32_t*)&depths[idx]);
+				gaussian_keys_unsorted[off] = key;
+				gaussian_values_unsorted[off] = idx;
+				off++;
+			}
+		}
+	}
+}
+
+// Check keys to see if it is at the start/end of one tile's range in 
+// the full sorted list. If yes, write start/end of this tile. 
+// Run once per instanced (duplicated) Gaussian ID.
+__global__ void identifyTileRanges(int L, uint64_t* point_list_keys, uint2* ranges)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= L)
+		return;
+
+	// Read tile ID from key. Update start/end of tile range if at limit.
+	uint64_t key = point_list_keys[idx];
+	uint32_t currtile = key >> 32;
+	if (idx == 0)
+		ranges[currtile].x = 0;
+	else
+	{
+		uint32_t prevtile = point_list_keys[idx - 1] >> 32;
+		if (currtile != prevtile)
+		{
+			ranges[prevtile].y = idx;
+			ranges[currtile].x = idx;
+		}
+	}
+	if (idx == L - 1)
+		ranges[currtile].y = L;
+}
+
+// Mark Gaussians as visible/invisible, based on view frustum testing
+void CudaRasterizer::Rasterizer::markVisible(
+	int P,
+	float* means3D,
+	float* viewmatrix,
+	float* projmatrix,
+	bool* present)
+{
+	checkFrustum << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		viewmatrix, projmatrix,
+		present);
+}
+
+CudaRasterizer::GeometryState CudaRasterizer::GeometryState::fromChunk(char*& chunk, size_t P)
+{
+	GeometryState geom;
+	obtain(chunk, geom.depths, P, 128);
+	obtain(chunk, geom.internal_radii, P, 128);
+	obtain(chunk, geom.means2D, P, 128);
+	obtain(chunk, geom.cov3D, P * 6, 128);
+	obtain(chunk, geom.conic_opacity, P, 128);
+	obtain(chunk, geom.etas, P, 128);
+	obtain(chunk, geom.tiles_touched, P, 128);
+	cub::DeviceScan::InclusiveSum(nullptr, geom.scan_size, geom.tiles_touched, geom.tiles_touched, P);
+	obtain(chunk, geom.scanning_space, geom.scan_size, 128);
+	obtain(chunk, geom.point_offsets, P, 128);
+	return geom;
+}
+
+CudaRasterizer::ImageState CudaRasterizer::ImageState::fromChunk(char*& chunk, size_t N)
+{
+	ImageState img;
+	obtain(chunk, img.n_contrib, N, 128);
+	obtain(chunk, img.ranges, N, 128);
+	return img;
+}
+
+CudaRasterizer::BinningState CudaRasterizer::BinningState::fromChunk(char*& chunk, size_t P)
+{
+	BinningState binning;
+	obtain(chunk, binning.point_list, P, 128);
+	obtain(chunk, binning.point_list_unsorted, P, 128);
+	obtain(chunk, binning.point_list_keys, P, 128);
+	obtain(chunk, binning.point_list_keys_unsorted, P, 128);
+	cub::DeviceRadixSort::SortPairs(
+		nullptr, binning.sorting_size,
+		binning.point_list_keys_unsorted, binning.point_list_keys,
+		binning.point_list_unsorted, binning.point_list, P);
+	obtain(chunk, binning.list_sorting_space, binning.sorting_size, 128);
+	return binning;
+}
+
+// Forward rendering procedure for differentiable rasterization
+// of Gaussians.
+int CudaRasterizer::Rasterizer::forward(
+	std::function<char* (size_t)> geometryBuffer,
+	std::function<char* (size_t)> binningBuffer,
+	std::function<char* (size_t)> imageBuffer,
+	const int P, 
+	const int width, int height,
+	const float* means3D,
+	const float* opacities,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float* cam_pos,
+	const float tan_fovx, float tan_fovy,
+	const bool prefiltered,
+	const int mode,
+	float* out_color,
+	float* out_others,
+	int* radii,
+	bool debug)
+{	
+
+	const float focal_y = height / (2.0f * tan_fovy);  // tan_fovy=1 when parallel  focal_y = height * (DSD / proj_phy_h)
+	const float focal_x = width / (2.0f * tan_fovx); // tan_fovx=1 when parallel   focal_x = weight * (DSD / proj_phy_w)
+
+	size_t chunk_size = required<GeometryState>(P);
+	char* chunkptr = geometryBuffer(chunk_size);
+	GeometryState geomState = GeometryState::fromChunk(chunkptr, P);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
+	dim3 block(BLOCK_X, BLOCK_Y, 1);
+
+	// Dynamically resize image-based auxiliary buffers during training
+	size_t img_chunk_size = required<ImageState>(width * height);
+	char* img_chunkptr = imageBuffer(img_chunk_size);
+	ImageState imgState = ImageState::fromChunk(img_chunkptr, width * height);
+
+    if (NUM_CHANNELS != 1)
+    {
+        throw std::runtime_error("This version of Diff Gaussian Splatting only handle opacity, not RGB");
+    }
+
+	// Run preprocessing per-Gaussian (transformation, bounding, conversion of SHs to RGB)
+	CHECK_CUDA(FORWARD::preprocess(
+		P, 
+		means3D,
+		(glm::vec3*)scales,
+		scale_modifier,
+		(glm::vec4*)rotations,
+		opacities,
+		cov3D_precomp,
+		viewmatrix, projmatrix,
+		(glm::vec3*)cam_pos,
+		width, height,
+		focal_x, focal_y,
+		tan_fovx, tan_fovy,
+		radii,
+		geomState.means2D,
+		geomState.depths,
+		geomState.cov3D,
+		geomState.conic_opacity,
+		geomState.etas,
+		tile_grid,
+		geomState.tiles_touched,
+		prefiltered,
+		mode
+	), debug)
+
+	// Compute prefix sum over full list of touched tile counts by Gaussians
+	// E.g., [2, 3, 0, 2, 1] -> [2, 5, 5, 7, 8]
+	CHECK_CUDA(cub::DeviceScan::InclusiveSum(geomState.scanning_space, geomState.scan_size, geomState.tiles_touched, geomState.point_offsets, P), debug)
+
+	// Retrieve total number of Gaussian instances to launch and resize aux buffers
+	int num_rendered;
+	CHECK_CUDA(cudaMemcpy(&num_rendered, geomState.point_offsets + P - 1, sizeof(int), cudaMemcpyDeviceToHost), debug);
+
+	size_t binning_chunk_size = required<BinningState>(num_rendered);
+	char* binning_chunkptr = binningBuffer(binning_chunk_size);
+	BinningState binningState = BinningState::fromChunk(binning_chunkptr, num_rendered);
+
+	// For each instance to be rendered, produce adequate [ tile | depth ] key 
+	// and corresponding dublicated Gaussian indices to be sorted
+	duplicateWithKeys << <(P + 255) / 256, 256 >> > (
+		P,
+		geomState.means2D,
+		geomState.depths,
+		geomState.point_offsets,
+		binningState.point_list_keys_unsorted,
+		binningState.point_list_unsorted,
+		radii,
+		tile_grid)
+	CHECK_CUDA(, debug)
+
+	int bit = getHigherMsb(tile_grid.x * tile_grid.y);
+
+	// Sort complete list of (duplicated) Gaussian indices by keys
+	CHECK_CUDA(cub::DeviceRadixSort::SortPairs(
+		binningState.list_sorting_space,
+		binningState.sorting_size,
+		binningState.point_list_keys_unsorted, binningState.point_list_keys,
+		binningState.point_list_unsorted, binningState.point_list,
+		num_rendered, 0, 32 + bit), debug)
+
+	CHECK_CUDA(cudaMemset(imgState.ranges, 0, tile_grid.x * tile_grid.y * sizeof(uint2)), debug);
+
+	// Identify start and end of per-tile workloads in sorted list
+	if (num_rendered > 0)
+		identifyTileRanges << <(num_rendered + 255) / 256, 256 >> > (
+			num_rendered,
+			binningState.point_list_keys,
+			imgState.ranges);
+	CHECK_CUDA(, debug)
+
+	// Let each tile blend its range of Gaussians independently in parallel
+	CHECK_CUDA(FORWARD::render(
+		tile_grid, block,
+		imgState.ranges,
+		binningState.point_list,
+		width, height,
+		geomState.means2D,
+		geomState.conic_opacity,
+		geomState.etas,
+		imgState.n_contrib,
+		out_color,
+		out_others), debug)
+
+	return num_rendered;
+}
+
+// Produce necessary gradients for optimization, corresponding
+// to forward render pass
+void CudaRasterizer::Rasterizer::backward(
+	const int P, int R, 
+	const int width, int height,
+	const float* means3D,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float* campos,
+	const float tan_fovx, float tan_fovy,
+	const int* radii,
+	char* geom_buffer,
+	char* binning_buffer,
+	char* img_buffer,
+	const float* dL_dpix,
+	float* dL_dmean2D,
+	float* dL_dconic,
+	float* dL_dopacity,
+	float* dL_deta,
+	float* dL_dmean3D,
+	float* dL_dcov3D,
+	float* dL_dscale,
+	float* dL_drot,
+	const int mode,
+	bool debug)
+{
+	GeometryState geomState = GeometryState::fromChunk(geom_buffer, P);
+	BinningState binningState = BinningState::fromChunk(binning_buffer, R);
+	ImageState imgState = ImageState::fromChunk(img_buffer, width * height);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	const float focal_y = height / (2.0f * tan_fovy);  // tan_fovy=1 when parallel  focal_y = height * (DSD / proj_phy_h)
+	const float focal_x = width / (2.0f * tan_fovx); // tan_fovx=1 when parallel   focal_x = weight * (DSD / proj_phy_w)
+
+	const dim3 tile_grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
+	const dim3 block(BLOCK_X, BLOCK_Y, 1);
+
+	// Compute loss gradients w.r.t. 2D mean position, conic matrix,
+	// opacity and RGB of Gaussians from per-pixel loss gradients.
+	// If we were given precomputed colors and not SHs, use them.
+	CHECK_CUDA(BACKWARD::render(
+		tile_grid,
+		block,
+		imgState.ranges,
+		binningState.point_list,
+		width, height,
+		geomState.means2D,
+		geomState.conic_opacity,
+		geomState.etas,
+		imgState.n_contrib,
+		dL_dpix,
+		(float3*)dL_dmean2D,
+		(float4*)dL_dconic,
+		dL_dopacity,
+		dL_deta), debug)
+
+	// Take care of the rest of preprocessing. Was the precomputed covariance
+	// given to us or a scales/rot pair? If precomputed, pass that. If not,
+	// use the one we computed ourselves.
+	const float* cov3D_ptr = (cov3D_precomp != nullptr) ? cov3D_precomp : geomState.cov3D;
+	CHECK_CUDA(BACKWARD::preprocess(P, 
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		cov3D_ptr,
+		viewmatrix,
+		projmatrix,
+		focal_x, focal_y,
+		tan_fovx, tan_fovy,
+		(glm::vec3*)campos,
+		(float3*)dL_dmean2D,
+		dL_dconic,
+		dL_deta,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		(glm::vec3*)dL_dscale,
+		(glm::vec4*)dL_drot,
+		mode), debug)
+
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_rasterizer/rasterizer_impl.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include "rasterizer.h"
+#include <cuda_runtime_api.h>
+
+namespace CudaRasterizer
+{
+	template <typename T>
+	static void obtain(char*& chunk, T*& ptr, std::size_t count, std::size_t alignment)
+	{
+		std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
+		ptr = reinterpret_cast<T*>(offset);
+		chunk = reinterpret_cast<char*>(ptr + count);
+	}
+
+	struct GeometryState
+	{
+		size_t scan_size;
+		float* depths;
+		char* scanning_space;
+		int* internal_radii;
+		float2* means2D;
+		float* cov3D;
+		float4* conic_opacity;
+		float* etas;
+		uint32_t* point_offsets;
+		uint32_t* tiles_touched;
+
+		static GeometryState fromChunk(char*& chunk, size_t P);
+	};
+
+	struct ImageState
+	{
+		uint2* ranges;
+		uint32_t* n_contrib;
+
+		static ImageState fromChunk(char*& chunk, size_t N);
+	};
+
+	struct BinningState
+	{
+		size_t sorting_size;
+		uint64_t* point_list_keys_unsorted;
+		uint64_t* point_list_keys;
+		uint32_t* point_list_unsorted;
+		uint32_t* point_list;
+		char* list_sorting_space;
+
+		static BinningState fromChunk(char*& chunk, size_t P);
+	};
+
+	template<typename T> 
+	size_t required(size_t P)
+	{
+		char* size = nullptr;
+		T::fromChunk(size, P);
+		return ((size_t)size) + 128;
+	}
+};

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/auxiliary.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/auxiliary.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef cuda_voxelizer_AUXILIARY_H_INCLUDED
+#define cuda_voxelizer_AUXILIARY_H_INCLUDED
+
+#include "config.h"
+#include "stdio.h"
+
+#define BLOCK3D_SIZE (BLOCK3D_X * BLOCK3D_Y * BLOCK3D_Z)
+#define NUM_WARPS3D (BLOCK_SIZE3D/32)
+#define VOXEL_AXUTILITY_GEO_FORWARD 1
+#define VOXEL_AXUTILITY_GEO_BACKWARD 1
+#define GEO_OFFSET 0
+
+
+// struct float7 {
+//     float a, b, c, d, e, f, o;
+
+//     // Default constructor
+//     __host__ __device__ float7() : a(0), b(0), c(0), d(0), e(0), f(0), o(0) {}
+
+//     // Parameterized constructor
+//     __host__ __device__ float7(float a, float b, float c, float d, float e, float f, float o) 
+//     : a(a), b(b), c(c), d(d), e(e), f(f), o(o) {}
+// };
+
+__forceinline__ __device__ void getCube(const float3 p, int max_radius, uint3& cube_min, uint3& cube_max, dim3 grid)
+{
+	cube_min = {
+		min(grid.x, max((int)0, (int)((p.x - max_radius) / BLOCK3D_X))),
+		min(grid.y, max((int)0, (int)((p.y - max_radius) / BLOCK3D_Y))),
+		min(grid.z, max((int)0, (int)((p.z - max_radius) / BLOCK3D_Z)))
+	};
+	cube_max = {
+		min(grid.x, max((int)0, (int)((p.x + max_radius + BLOCK3D_X - 1) / BLOCK3D_X))),
+		min(grid.y, max((int)0, (int)((p.y + max_radius + BLOCK3D_Y - 1) / BLOCK3D_Y))),
+		min(grid.z, max((int)0, (int)((p.z + max_radius + BLOCK3D_Z - 1) / BLOCK3D_Z)))
+	};
+}
+
+__forceinline__ __device__ float3 transformPoint4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float4 transformPoint4x4(const float3& p, const float* matrix)
+{
+	float4 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+		matrix[3] * p.x + matrix[7] * p.y + matrix[11] * p.z + matrix[15]
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z,
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z,
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3Transpose(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[1] * p.y + matrix[2] * p.z,
+		matrix[4] * p.x + matrix[5] * p.y + matrix[6] * p.z,
+		matrix[8] * p.x + matrix[9] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float dnormvdz(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+	float dnormvdz = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdz;
+}
+
+__forceinline__ __device__ float3 dnormvdv(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float3 dnormvdv;
+	dnormvdv.x = ((+sum2 - v.x * v.x) * dv.x - v.y * v.x * dv.y - v.z * v.x * dv.z) * invsum32;
+	dnormvdv.y = (-v.x * v.y * dv.x + (sum2 - v.y * v.y) * dv.y - v.z * v.y * dv.z) * invsum32;
+	dnormvdv.z = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float4 dnormvdv(float4 v, float4 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float4 vdv = { v.x * dv.x, v.y * dv.y, v.z * dv.z, v.w * dv.w };
+	float vdv_sum = vdv.x + vdv.y + vdv.z + vdv.w;
+	float4 dnormvdv;
+	dnormvdv.x = ((sum2 - v.x * v.x) * dv.x - v.x * (vdv_sum - vdv.x)) * invsum32;
+	dnormvdv.y = ((sum2 - v.y * v.y) * dv.y - v.y * (vdv_sum - vdv.y)) * invsum32;
+	dnormvdv.z = ((sum2 - v.z * v.z) * dv.z - v.z * (vdv_sum - vdv.z)) * invsum32;
+	dnormvdv.w = ((sum2 - v.w * v.w) * dv.w - v.w * (vdv_sum - vdv.w)) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float sigmoid(float x)
+{
+	return 1.0f / (1.0f + expf(-x));
+}
+
+__forceinline__ __device__ bool in_frustum(int idx,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool prefiltered,
+	float3& p_view)
+{
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// Bring points to screen space
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+	p_view = transformPoint4x3(p_orig, viewmatrix);
+
+	if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	{
+		if (prefiltered)
+		{
+			printf("Point is filtered although prefiltered is set. This shouldn't happen!");
+			__trap();
+		}
+		return false;
+	}
+	return true;
+}
+
+#define CHECK_CUDA(A, debug) \
+A; if(debug) { \
+auto ret = cudaDeviceSynchronize(); \
+if (ret != cudaSuccess) { \
+std::cerr << "\n[CUDA ERROR] in " << __FILE__ << "\nLine " << __LINE__ << ": " << cudaGetErrorString(ret); \
+throw std::runtime_error(cudaGetErrorString(ret)); \
+} \
+}
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/backward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/backward.cu
@@ -1,0 +1,463 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "backward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+
+// Backward pass for the conversion of scale and rotation to a 
+// 3D covariance matrix for each Gaussian. 
+__device__ void computeCov3D2(int idx, const glm::vec3 scale, float mod, const glm::vec4 rot, const float* dL_dcov3Ds, glm::vec3* dL_dscales, glm::vec4* dL_drots)
+{
+	// Recompute (intermediate) results for the 3D covariance computation.
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 S = glm::mat3(1.0f);
+
+	glm::vec3 s = mod * scale;
+	S[0][0] = s.x;
+	S[1][1] = s.y;
+	S[2][2] = s.z;
+
+	glm::mat3 M = S * R;
+
+	const float* dL_dcov3D = dL_dcov3Ds + 6 * idx;
+
+	glm::vec3 dunc(dL_dcov3D[0], dL_dcov3D[3], dL_dcov3D[5]);
+	glm::vec3 ounc = 0.5f * glm::vec3(dL_dcov3D[1], dL_dcov3D[2], dL_dcov3D[4]);
+
+	// Convert per-element covariance loss gradients to matrix form
+	glm::mat3 dL_dSigma = glm::mat3(
+		dL_dcov3D[0], 0.5f * dL_dcov3D[1], 0.5f * dL_dcov3D[2],
+		0.5f * dL_dcov3D[1], dL_dcov3D[3], 0.5f * dL_dcov3D[4],
+		0.5f * dL_dcov3D[2], 0.5f * dL_dcov3D[4], dL_dcov3D[5]
+	);
+
+	// Compute loss gradient w.r.t. matrix M
+	// dSigma_dM = 2 * M
+	glm::mat3 dL_dM = 2.0f * M * dL_dSigma;
+
+	glm::mat3 Rt = glm::transpose(R);
+	glm::mat3 dL_dMt = glm::transpose(dL_dM);
+
+	// Gradients of loss w.r.t. scale
+	glm::vec3* dL_dscale = dL_dscales + idx;
+	dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
+	dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
+	dL_dscale->z = glm::dot(Rt[2], dL_dMt[2]);
+
+	dL_dMt[0] *= s.x;
+	dL_dMt[1] *= s.y;
+	dL_dMt[2] *= s.z;
+
+	// Gradients of loss w.r.t. normalized quaternion
+	glm::vec4 dL_dq;
+	dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2] - dL_dMt[2][1]);
+	dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2] - dL_dMt[2][1]) - 4 * x * (dL_dMt[2][2] + dL_dMt[1][1]);
+	dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * y * (dL_dMt[2][2] + dL_dMt[0][0]);
+	dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
+
+	// Gradients of loss w.r.t. unnormalized quaternion
+	float4* dL_drot = (float4*)(dL_drots + idx);
+	*dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w };//dnormvdv(float4{ rot.x, rot.y, rot.z, rot.w }, float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w });
+}
+
+__global__ void computeCov3DCUDA(int P,
+	const float3* means,
+	const int* radii,
+	const float* cov3Ds,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float* dL_dconic3D,
+	float3* dL_dmean3D,
+	float* dL_dcov)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	float dVoxel_x = sVoxel_x / (float)nVoxel_x;
+	float dVoxel_y = sVoxel_y / (float)nVoxel_y;
+	float dVoxel_z = sVoxel_z / (float)nVoxel_z;
+	
+	// Reading location of 3D covariance for this Gaussian
+	const float* cov3D = cov3Ds + 6 * idx;
+	float3 mean = means[idx];
+
+	float dL_dconic_a = dL_dconic3D[idx * 6 + 0];
+	float dL_dconic_b = dL_dconic3D[idx * 6 + 1];
+	float dL_dconic_c = dL_dconic3D[idx * 6 + 2];
+	float dL_dconic_d = dL_dconic3D[idx * 6 + 3];
+	float dL_dconic_e = dL_dconic3D[idx * 6 + 4];
+	float dL_dconic_f = dL_dconic3D[idx * 6 + 5];
+
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+	glm::mat3 M = glm::mat3(
+		1.0f / dVoxel_x, 0.0f, 0.0f,
+		0.0f, 1.0f  / dVoxel_y, 0.0f,
+		0.0f, 0.0f, 1.0f / dVoxel_z);
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+
+	float hata = cov[0][0];
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1];
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+	float denom = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	float denom2inv = 1.0f / ((denom * denom) + 0.0000001f);
+
+	float dL_dhata = 0, dL_dhatb = 0, dL_dhatc = 0, dL_dhatd = 0, dL_dhate = 0, dL_dhatf = 0;
+
+	if (denom2inv != 0)
+	{
+		float denom_da = hatd * hatf - hate * hate;
+		float denom_db = 2 * hatc * hate - 2 * hatf * hatb;
+		float denom_dc = 2 * hatb * hate - 2 * hatd * hatc;
+		float denom_dd = hata * hatf - hatc * hatc;
+		float denom_de = 2 * hatb * hatc - 2 * hata * hate;
+		float denom_df = hata * hatd - hatb * hatb;
+		
+		float ce_bf = hatc * hate - hatb * hatf;
+		float be_cd = hatb * hate - hatc * hatd;
+		float bc_ae = hatb * hatc - hata * hate;
+
+		dL_dhata = denom2inv * (-denom_da*denom_da*dL_dconic_a - ce_bf*denom_da*dL_dconic_b - be_cd*denom_da*dL_dconic_c + (hatf*denom-denom_dd*denom_da)*dL_dconic_d + (-hate*denom-bc_ae*denom_da)*dL_dconic_e + (hatd*denom-denom_df*denom_da)*dL_dconic_f);
+		dL_dhatb = denom2inv * (-denom_da*denom_db*dL_dconic_a + (-hatf*denom-ce_bf*denom_db)*dL_dconic_b + (hate*denom-be_cd*denom_db)*dL_dconic_c - denom_dd*denom_db*dL_dconic_d + (hatc*denom-bc_ae*denom_db)*dL_dconic_e + (-2*hatb*denom-denom_df*denom_db)*dL_dconic_f);
+		dL_dhatc = denom2inv * (-denom_da*denom_dc*dL_dconic_a + (hate*denom-ce_bf*denom_dc)*dL_dconic_b + (-hatd*denom-be_cd*denom_dc)*dL_dconic_c + (-2*hatc*denom-denom_dd*denom_dc)*dL_dconic_d + (hatb*denom-bc_ae*denom_dc)*dL_dconic_e - denom_df*denom_dc*dL_dconic_f);
+		dL_dhatd = denom2inv * ((hatf*denom-denom_da*denom_dd)*dL_dconic_a - ce_bf*denom_dd*dL_dconic_b +(-hatc*denom-be_cd*denom_dd)*dL_dconic_c - denom_dd*denom_dd*dL_dconic_d - bc_ae*denom_dd*dL_dconic_e + (hata*denom-denom_df*denom_dd)*dL_dconic_f);
+		dL_dhate = denom2inv * ((-2*hate*denom-denom_da*denom_de)*dL_dconic_a + (hatc*denom-ce_bf*denom_de)*dL_dconic_b + (hatb*denom-be_cd*denom_de)*dL_dconic_c - denom_dd*denom_de*dL_dconic_d + (-hata*denom-bc_ae*denom_de)*dL_dconic_e + -denom_df*denom_de*dL_dconic_f);
+		dL_dhatf = denom2inv * ((hatd*denom-denom_da*denom_df)*dL_dconic_a + (-hatb*denom-ce_bf*denom_df)*dL_dconic_b - be_cd*denom_df*dL_dconic_c + (hata*denom-denom_dd*denom_df)*dL_dconic_d - bc_ae*denom_df*dL_dconic_e - denom_df*denom_df*dL_dconic_f);
+
+		// Gradients of loss L w.r.t. each 3D covariance matrix (Vrk) entry
+		// dL_da
+		dL_dcov[6 * idx + 0] += M[0][0]*M[0][0]*dL_dhata + M[0][0]*M[1][0]*dL_dhatb + M[0][0]*M[2][0]*dL_dhatc + M[1][0]*M[1][0]*dL_dhatd + M[1][0]*M[2][0]*dL_dhate + M[2][0]*M[2][0]*dL_dhatf;
+		// dL_dd
+		dL_dcov[6 * idx + 3] += M[0][1]*M[0][1]*dL_dhata + M[0][1]*M[1][1]*dL_dhatb + M[0][1]*M[2][1]*dL_dhatc + M[1][1]*M[1][1]*dL_dhatd + M[1][1]*M[2][1]*dL_dhate + M[2][1]*M[2][1]*dL_dhatf;
+		// dL_df
+		dL_dcov[6 * idx + 5] += M[0][2]*M[0][2]*dL_dhata + M[0][2]*M[1][2]*dL_dhatb + M[0][2]*M[2][2]*dL_dhatc + M[1][2]*M[1][2]*dL_dhatd + M[1][2]*M[2][2]*dL_dhate + M[2][2]*M[2][2]*dL_dhatf;
+		
+		// dL_db
+		dL_dcov[6 * idx + 1] += 2*M[0][0]*M[0][1]*dL_dhata + (M[0][1]*M[1][0]+M[0][0]*M[1][1])*dL_dhatb + (M[0][1]*M[2][0]+M[0][0]*M[2][1])*dL_dhatc + 2*M[1][0]*M[1][1]*dL_dhatd + (M[1][1]*M[2][0]+M[1][0]*M[2][1])*dL_dhate + 2*M[2][0]*M[2][1]*dL_dhatf;
+		// dL_dc
+		dL_dcov[6 * idx + 2] += 2*M[0][0]*M[0][2]*dL_dhata + (M[0][2]*M[1][0]+M[0][0]*M[1][2])*dL_dhatb + (M[0][2]*M[2][0]+M[0][0]*M[2][2])*dL_dhatc + 2*M[1][0]*M[1][2]*dL_dhatd + (M[1][2]*M[2][0]+M[1][0]*M[2][2])*dL_dhate + 2*M[2][0]*M[2][2]*dL_dhatf;
+		// dL_de
+		dL_dcov[6 * idx + 4] += 2*M[0][1]*M[0][2]*dL_dhata + (M[0][2]*M[1][1]+M[0][1]*M[1][2])*dL_dhatb + (M[0][2]*M[2][1]+M[0][1]*M[2][2])*dL_dhatc + 2*M[1][1]*M[1][2]*dL_dhatd + (M[1][2]*M[2][1]+M[1][1]*M[2][2])*dL_dhate + 2*M[2][1]*M[2][2]*dL_dhatf;
+	}
+	else
+	{
+		for (int i = 0; i < 6; i++)
+			dL_dcov[6 * idx + i] = 0;
+	}
+}
+
+
+template<int C>
+__global__ void preprocessCUDA(
+	int P,
+	const float3* means,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float3* dL_dmean3D_norm,
+	glm::vec3* dL_dmeans,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	glm::vec3 dL_dmean;
+	dL_dmean.x = dL_dmean3D_norm[idx].x;
+	dL_dmean.y = dL_dmean3D_norm[idx].y;
+	dL_dmean.z = dL_dmean3D_norm[idx].z;
+
+	// printf("dL_dmean.x: %f\n", dL_dmean.x);
+	// printf("dL_dmean.y: %f\n", dL_dmean.y);
+	// printf("dL_dmean.z: %f\n", dL_dmean.z);
+	
+	dL_dmeans[idx] += dL_dmean;
+
+	// Compute gradient updates due to computing covariance from scale/rotation
+	if (scales)
+		computeCov3D2(idx, scales[idx], scale_modifier, rotations[idx], dL_dcov3D, dL_dscale, dL_drot);
+
+}
+
+// Backward version of the rendering procedure.
+template <uint32_t C>
+__global__ void __launch_bounds__(BLOCK3D_X * BLOCK3D_Y * BLOCK3D_Z)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float3* __restrict__ points_xyz_vol,
+	const float* __restrict__ conic_opacity,
+	const uint32_t* __restrict__ n_contrib,
+	const float* __restrict__ dL_dpixels,
+	const float* __restrict__ dL_dothers,
+	float3* __restrict__ dL_dmean3D_norm,
+	float* __restrict__ dL_dconic3D,
+	float* __restrict__ dL_dopacity)
+{
+	auto block = cg::this_thread_block();
+
+	float dVoxel_x = sVoxel_x / (float)nVoxel_x;
+	float dVoxel_y = sVoxel_y / (float)nVoxel_y;
+	float dVoxel_z = sVoxel_z / (float)nVoxel_z;
+
+	uint32_t horizontal_blocks1 = (nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X;
+	uint32_t horizontal_blocks2 = (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y;
+	uint3 voxel_min = { block.group_index().x * BLOCK3D_X, block.group_index().y * BLOCK3D_Y,  block.group_index().z * BLOCK3D_Z};
+	uint3 voxel_max = { min(voxel_min.x + BLOCK3D_X, nVoxel_x), min(voxel_min.y + BLOCK3D_Y , nVoxel_y),  min(voxel_min.z + BLOCK3D_Z , nVoxel_z)};
+	uint3 voxel = { voxel_min.x + block.thread_index().x, voxel_min.y + block.thread_index().y, voxel_min.z + block.thread_index().z};
+	uint32_t voxel_id = nVoxel_z * nVoxel_y * voxel.x + nVoxel_z * voxel.y + voxel.z;
+	// add 0.5 because we donnot count offset previously, like gs code in ndc2pixel()
+	float3 voxelf = { (float)voxel.x + 0.5f, (float)voxel.y + 0.5f, (float)voxel.z + 0.5f};
+
+	// Check if this thread is associated with a valid pixel or outside.
+	bool inside = voxel.x < nVoxel_x && voxel.y < nVoxel_y && voxel.z < nVoxel_z;
+	// Done threads can help with fetching, but don't rasterize
+	bool done = !inside;
+
+	// Load start/end range of IDs to process in bit sorted list.
+	uint2 range = ranges[block.group_index().z * horizontal_blocks2 * horizontal_blocks1 + block.group_index().y * horizontal_blocks1 + block.group_index().x];
+	const int rounds = ((range.y - range.x + BLOCK3D_SIZE - 1) / BLOCK3D_SIZE);
+	int toDo = range.y - range.x;
+
+	// Allocate storage for batches of collectively fetched data.
+	__shared__ int collected_id[BLOCK3D_SIZE];
+	__shared__ float3 collected_xyz[BLOCK3D_SIZE];
+	__shared__ float collected_conic_a[BLOCK3D_SIZE];
+	__shared__ float collected_conic_b[BLOCK3D_SIZE];
+	__shared__ float collected_conic_c[BLOCK3D_SIZE];
+	__shared__ float collected_conic_d[BLOCK3D_SIZE];
+	__shared__ float collected_conic_e[BLOCK3D_SIZE];
+	__shared__ float collected_conic_f[BLOCK3D_SIZE];
+	__shared__ float collected_o[BLOCK3D_SIZE];
+
+	// We start from the back. The ID of the last contributing
+	// Gaussian is known from each pixel from the forward.
+	uint32_t contributor = toDo;
+	const int last_contributor = inside ? n_contrib[voxel_id] : 0;
+
+	float dL_dpixel[C];
+	if (inside)
+		for (int i = 0; i < C; i++)
+			dL_dpixel[i] = dL_dpixels[i *  nVoxel_x * nVoxel_y * nVoxel_z + voxel_id];
+	
+	#if VOXEL_AXUTILITY_GEO_BACKWARD
+		float dL_dgeo;
+		if (inside)
+			dL_dgeo = dL_dothers[GEO_OFFSET * nVoxel_x * nVoxel_y * nVoxel_z + voxel_id];
+	#endif
+	
+	// Gradient of pixel coordinate w.r.t. normalized 
+	// screen-space viewport corrdinates (-1 to 1)
+	const float ddelx_dx = dVoxel_x;
+	const float ddely_dy = dVoxel_y;
+	const float ddelz_dz = dVoxel_z;
+
+	// Traverse all Gaussians
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK3D_SIZE)
+	{
+		// Load auxiliary data into shared memory, start in the BACK
+		// and load them in revers order.
+		block.sync();
+		const int progress = i * BLOCK3D_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			const int coll_id = point_list[range.y - progress - 1];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xyz[block.thread_rank()] = points_xyz_vol[coll_id];
+			collected_conic_a[block.thread_rank()] = conic_opacity[coll_id * 7 + 0];
+			collected_conic_b[block.thread_rank()] = conic_opacity[coll_id * 7 + 1];
+			collected_conic_c[block.thread_rank()] = conic_opacity[coll_id * 7 + 2];
+			collected_conic_d[block.thread_rank()] = conic_opacity[coll_id * 7 + 3];
+			collected_conic_e[block.thread_rank()] = conic_opacity[coll_id * 7 + 4];
+			collected_conic_f[block.thread_rank()] = conic_opacity[coll_id * 7 + 5];
+			collected_o[block.thread_rank()] = conic_opacity[coll_id * 7 + 6];
+		}
+		block.sync();
+
+		// Iterate over Gaussians
+		for (int j = 0; !done && j < min(BLOCK3D_SIZE, toDo); j++)
+		{
+			// Keep track of current Gaussian ID. Skip, if this one
+			// is behind the last contributor for this pixel.
+			contributor--;
+			if (contributor >= last_contributor)
+				continue;
+
+			// Compute blending values, as before.
+
+			float3 xyz = collected_xyz[j];
+			float3 d = { xyz.x - voxelf.x, xyz.y - voxelf.y, xyz.z - voxelf.z };
+			float conic_a = collected_conic_a[j];
+			float conic_b = collected_conic_b[j];
+			float conic_c = collected_conic_c[j];
+			float conic_d = collected_conic_d[j];
+			float conic_e = collected_conic_e[j];
+			float conic_f = collected_conic_f[j];
+			float opa = collected_o[j];
+
+			float power = - 0.5 * (conic_a * d.x * d.x + conic_d * d.y * d.y + conic_f * d.z * d.z) - conic_b * d.x * d.y - conic_c * d.x * d.z - conic_e * d.y * d.z;
+
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			float alpha = opa * G;
+			float dL_dG = 0;
+			#if VOXEL_AXUTILITY_GEO_BACKWARD	
+				//*** propagate gradients of geo reg term ***//
+				dL_dG += dL_dgeo;
+			#endif				
+
+			if (alpha < 0.000001f)
+				continue;
+			
+			// Propagate gradients to per-Gaussian colors and keep
+			// gradients w.r.t. alpha (blending factor for a Gaussian/pixel
+			// pair).
+			// Since we are simple sum, dchannel_dalpha = 1.0
+			float dL_dalpha = 0.0f;
+			const int global_id = collected_id[j];
+			for (int ch = 0; ch < C; ch++)
+			{
+				const float dL_dchannel = dL_dpixel[ch];
+				dL_dalpha += 1.0f * dL_dchannel;
+			}
+
+			// Helpful reusable temporary variables
+			dL_dG += opa * dL_dalpha;
+			const float gdx = G * d.x;
+			const float gdy = G * d.y;
+			const float gdz = G * d.z;
+			const float dG_ddelx = - conic_a * gdx - conic_b * gdy - conic_c * gdz;
+			const float dG_ddely = - conic_d * gdy - conic_b * gdx - conic_e * gdz;
+			const float dG_ddelz = - conic_f * gdz - conic_c * gdx - conic_e * gdy;
+
+			atomicAdd(&dL_dmean3D_norm[global_id].x, dL_dG * dG_ddelx * ddelx_dx); // ddelx_dx is used to compensate ndc2pix
+			atomicAdd(&dL_dmean3D_norm[global_id].y, dL_dG * dG_ddely * ddely_dy); // ddelx_dx is used to compensate ndc2pix
+			atomicAdd(&dL_dmean3D_norm[global_id].z, dL_dG * dG_ddelz * ddelz_dz); // ddelx_dx is used to compensate ndc2pix
+
+			atomicAdd(&dL_dconic3D[global_id * 6 + 0], - 0.5 * gdx * d.x * dL_dG);  // conic_a
+			atomicAdd(&dL_dconic3D[global_id * 6 + 1], - 1.0 * gdx * d.y * dL_dG);  // conic_b
+			atomicAdd(&dL_dconic3D[global_id * 6 + 2], - 1.0 * gdx * d.z * dL_dG);  // conic_c
+			atomicAdd(&dL_dconic3D[global_id * 6 + 3], - 0.5 * gdy * d.y * dL_dG);  // conic_d
+			atomicAdd(&dL_dconic3D[global_id * 6 + 4], - 1.0 * gdy * d.z * dL_dG);  // conic_e
+			atomicAdd(&dL_dconic3D[global_id * 6 + 5], - 0.5 * gdz * d.z * dL_dG);  // conic_f
+
+			atomicAdd(&dL_dopacity[global_id], G * dL_dalpha);
+		}
+	}
+	
+}
+
+
+void BACKWARD::preprocess(
+	int P,
+	const float3* means3D,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* cov3Ds,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float3* dL_dmean3D_norm,
+	const float* dL_dconic3D,
+	glm::vec3* dL_dmean3D,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	computeCov3DCUDA << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		radii,
+		cov3Ds,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		dL_dconic3D,
+		(float3*)dL_dmean3D,
+		dL_dcov3D);
+
+	preprocessCUDA<NUM_CHANNELS> << < (P + 255) / 256, 256 >> > (
+		P,
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		(float3*)dL_dmean3D_norm,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		dL_dscale,
+		dL_drot);
+
+}
+
+void BACKWARD::render(
+	const dim3 grid, const dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float3* means3D_norm,
+	const float* conic_opacity,
+	const uint32_t* n_contrib,
+	const float* dL_dpixels,
+	const float* dL_dothers,
+	float3* dL_dmean3D_norm,
+	float* dL_dconic3D,
+	float* dL_dopacity
+	)
+{
+	renderCUDA<NUM_CHANNELS> << <grid, block >> >(
+		ranges,
+		point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		means3D_norm,
+		conic_opacity,
+		n_contrib,
+		dL_dpixels,
+		dL_dothers,
+		dL_dmean3D_norm,
+		dL_dconic3D,
+		dL_dopacity
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/backward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/backward.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef cuda_voxelizer_BACKWARD_H_INCLUDED
+#define cuda_voxelizer_BACKWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+
+namespace BACKWARD
+{
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+		const float3* means3D_norm,
+		const float* conic_opacity,
+		const uint32_t* n_contrib,
+		const float* dL_dpixels,
+		const float* dL_dothers,
+		float3* dL_dmean3D_norm,
+		float* dL_dconic3D,
+		float* dL_dopacity);
+
+	void preprocess(
+		int P,
+		const float3* means,
+		const int* radii,
+		const glm::vec3* scales,
+		const glm::vec4* rotations,
+		const float scale_modifier,
+		const float* cov3Ds,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+		const float center_x, float center_y, float center_z,
+		const float3* dL_dmean3D_norm,
+		const float* dL_dconic3D,
+		glm::vec3* dL_dmean3D,
+		float* dL_dcov3D,
+		glm::vec3* dL_dscale,
+		glm::vec4* dL_drot);
+}
+
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/config.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/config.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef cuda_voxelizer_CONFIG_H_INCLUDED
+#define cuda_voxelizer_CONFIG_H_INCLUDED
+
+#define NUM_CHANNELS 1
+#define BLOCK3D_X 8
+#define BLOCK3D_Y 8
+#define BLOCK3D_Z 8
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/forward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/forward.cu
@@ -1,0 +1,391 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+#include <stdio.h> // for debug
+#include "forward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Forward method for converting scale and rotation properties of each
+// Gaussian to a 3D covariance matrix in world space. Also takes care
+// of quaternion normalization.
+__device__ void computeCov3D2(const glm::vec3 scale, float mod, const glm::vec4 rot, float* cov3D)
+{
+	// Create scaling matrix
+	glm::mat3 S = glm::mat3(1.0f);
+	S[0][0] = mod * scale.x;
+	S[1][1] = mod * scale.y;
+	S[2][2] = mod * scale.z;
+
+	// Normalize quaternion to get valid rotation
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	// Compute rotation matrix from quaternion
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 M = S * R;
+
+	// Compute 3D world covariance matrix Sigma
+	glm::mat3 Sigma = glm::transpose(M) * M;
+
+	// Covariance is symmetric, only store upper right
+	cov3D[0] = Sigma[0][0];  // a
+	cov3D[1] = Sigma[0][1];  // b
+	cov3D[2] = Sigma[0][2];  // c
+	cov3D[3] = Sigma[1][1];  // d
+	cov3D[4] = Sigma[1][2];  // e
+	cov3D[5] = Sigma[2][2];  // f
+}
+
+
+template<int C>
+__global__ void preprocessCUDA(int P,
+	const float* orig_points,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	int* radii,
+	float3* points_xyz_vol,
+	float* depths,
+	float* cov3Ds,
+	float* conic_opacity,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered
+	)
+{
+    auto idx = cg::this_grid().thread_rank(); // idx
+	if (idx >= P)
+		return;
+
+	// printf("Now in preprocessCUDA\n");
+
+	// Initialize radius and touched tiles to 0. If this isn't changed,
+	// this Gaussian will not be processed further.
+	radii[idx] = 0;
+	tiles_touched[idx] = 0;
+
+	float dVoxel_x = sVoxel_x / (float)nVoxel_x;
+	float dVoxel_y = sVoxel_y / (float)nVoxel_y;
+	float dVoxel_z = sVoxel_z / (float)nVoxel_z;
+
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// If 3D covariance matrix is precomputed, use it, otherwise compute
+	// from scaling and rotation parameters. 
+	const float* cov3D;
+	if (cov3D_precomp != nullptr)
+	{
+		cov3D = cov3D_precomp + idx * 6;
+	}
+	else
+	{
+		computeCov3D2(scales[idx], scale_modifier, rotations[idx], cov3Ds + idx * 6);
+		cov3D = cov3Ds + idx * 6;
+	}
+
+	// Transfer to voxel space
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+	glm::mat3 M = glm::mat3(
+		1.f / dVoxel_x, 0.0f, 0.0f,
+		0.0f, 1.f  / dVoxel_y, 0.0f,
+		0.0f, 0.0f, 1.f / dVoxel_z);
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+	
+	float hata = cov[0][0];
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1];
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+	float det = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	if (det == 0.0f)
+		return;
+	float det_inv = 1.f / det;
+	float inv_a = (hatd * hatf - hate * hate) * det_inv;
+	float inv_b = (hatc * hate - hatb * hatf) * det_inv;
+	float inv_c = (hatb * hate - hatc * hatd) * det_inv;
+	float inv_d = (hata * hatf - hatc * hatc) * det_inv;
+	float inv_e = (hatb * hatc - hata * hate) * det_inv;
+	float inv_f = (hata * hatd - hatb * hatb) * det_inv;
+
+	// printf("inv_a: %f, inv_b: %f, inv_c: %f, inv_d: %f, inv_e: %f, inv_f: %f\n", inv_a, inv_b, inv_c, inv_d, inv_e, inv_f);
+	// glm::mat3 cov_inv = glm::inverse(cov);
+	// printf("cov_inv:\n");
+	// printf("%f\t%f\t%f\n", cov_inv[0][0], cov_inv[0][1], cov_inv[0][2]);
+	// printf("%f\t%f\t%f\n", cov_inv[1][0], cov_inv[1][1], cov_inv[1][2]);
+	// printf("%f\t%f\t%f\n", cov_inv[2][0], cov_inv[2][1], cov_inv[2][2]);
+
+	glm::vec3 scale = scales[idx];
+	float max_scale = max(max(scale.x / dVoxel_x, scale.y/ dVoxel_y), scale.z/ dVoxel_z); 
+	float my_radius = ceil(3.f * max_scale);
+
+	float3 point_vol = {(p_orig.x - center_x + sVoxel_x / 2) / dVoxel_x, 
+						(p_orig.y - center_y + sVoxel_y / 2) / dVoxel_y,
+						(p_orig.z - center_z + sVoxel_z / 2) / dVoxel_z};
+
+
+	if (point_vol.x < 0 || point_vol.y < 0 || point_vol.z < 0 || point_vol.x > (float)nVoxel_x || point_vol.y > (float)nVoxel_y || point_vol.z > (float)nVoxel_z)
+	{
+		return;
+	}
+
+	uint3 cube_min, cube_max;
+	getCube(point_vol, my_radius, cube_min, cube_max, grid);
+
+	if ((cube_max.x - cube_min.x) * (cube_max.y - cube_min.y) * (cube_max.z - cube_min.z) == 0)
+		return;
+	
+	radii[idx] = my_radius;
+	tiles_touched[idx] = (cube_max.z - cube_min.z) * (cube_max.y - cube_min.y) * (cube_max.x - cube_min.x);
+	depths[idx] = p_orig.z;  // just give a value
+	points_xyz_vol[idx] = point_vol;
+	conic_opacity[idx * 7 + 0] = inv_a;
+	conic_opacity[idx * 7 + 1] = inv_b;
+	conic_opacity[idx * 7 + 2] = inv_c;
+	conic_opacity[idx * 7 + 3] = inv_d;
+	conic_opacity[idx * 7 + 4] = inv_e;
+	conic_opacity[idx * 7 + 5] = inv_f;
+	conic_opacity[idx * 7 + 6] = opacities[idx];
+}
+
+// Main rasterization method. Collaboratively works on one tile per
+// block, each thread treats one pixel. Alternates between fetching 
+// and rasterizing data.
+template <uint32_t CHANNELS>
+__global__ void __launch_bounds__(BLOCK3D_X * BLOCK3D_Y * BLOCK3D_Z)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float3* __restrict__ points_xyz_vol,
+	const float* __restrict__ conic_opacity,
+	uint32_t* __restrict__ n_contrib,
+	float* __restrict__ out_volume,
+	float* __restrict__ out_others 
+	)
+{
+	
+	// Identify current tile and associated min/max pixel range.
+	auto block = cg::this_thread_block();
+
+	uint32_t horizontal_blocks1 = (nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X;
+	uint32_t horizontal_blocks2 = (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y;
+	uint3 voxel_min = { block.group_index().x * BLOCK3D_X, block.group_index().y * BLOCK3D_Y,  block.group_index().z * BLOCK3D_Z};
+	uint3 voxel_max = { min(voxel_min.x + BLOCK3D_X, nVoxel_x), min(voxel_min.y + BLOCK3D_Y , nVoxel_y),  min(voxel_min.z + BLOCK3D_Z , nVoxel_z)};
+	uint3 voxel = { voxel_min.x + block.thread_index().x, voxel_min.y + block.thread_index().y, voxel_min.z + block.thread_index().z};
+	uint32_t voxel_id = nVoxel_z * nVoxel_y * voxel.x + nVoxel_z * voxel.y + voxel.z;
+	// add 0.5 because we donnot count offset previously, like gs code in ndc2pixel()
+	float3 voxelf = { (float)voxel.x + 0.5f, (float)voxel.y + 0.5f, (float)voxel.z + 0.5f};
+
+	// Check if this thread is associated with a valid pixel or outside.
+	bool inside = voxel.x < nVoxel_x && voxel.y < nVoxel_y && voxel.z < nVoxel_z;
+	// Done threads can help with fetching, but don't rasterize
+	bool done = !inside;
+
+	// Load start/end range of IDs to process in bit sorted list.
+	uint2 range = ranges[block.group_index().z * horizontal_blocks2 * horizontal_blocks1 + block.group_index().y * horizontal_blocks1 + block.group_index().x];
+	const int rounds = ((range.y - range.x + BLOCK3D_SIZE - 1) / BLOCK3D_SIZE);
+	int toDo = range.y - range.x;
+
+	// Allocate storage for batches of collectively fetched data.
+	__shared__ int collected_id[BLOCK3D_SIZE];
+	__shared__ float3 collected_xyz[BLOCK3D_SIZE];
+	__shared__ float collected_conic_a[BLOCK3D_SIZE];
+	__shared__ float collected_conic_b[BLOCK3D_SIZE];
+	__shared__ float collected_conic_c[BLOCK3D_SIZE];
+	__shared__ float collected_conic_d[BLOCK3D_SIZE];
+	__shared__ float collected_conic_e[BLOCK3D_SIZE];
+	__shared__ float collected_conic_f[BLOCK3D_SIZE];
+	__shared__ float collected_o[BLOCK3D_SIZE];
+
+	// Initialize helper variables
+	uint32_t contributor = 0;
+	uint32_t last_contributor = 0;
+	float C[CHANNELS] = { 0 };
+
+	#if VOXEL_AXUTILITY_GEO_FORWARD
+		float geo = {0};
+	#endif
+
+	// Iterate over batches until all done or range is complete
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK3D_SIZE)
+	{
+		// End if entire block votes that it is done rasterizing
+		int num_done = __syncthreads_count(done);
+		if (num_done == BLOCK3D_SIZE)
+			break;
+
+		// Collectively fetch per-Gaussian data from global to shared
+		int progress = i * BLOCK3D_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			int coll_id = point_list[range.x + progress];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xyz[block.thread_rank()] = points_xyz_vol[coll_id];
+			collected_conic_a[block.thread_rank()] = conic_opacity[coll_id * 7 + 0];
+			collected_conic_b[block.thread_rank()] = conic_opacity[coll_id * 7 + 1];
+			collected_conic_c[block.thread_rank()] = conic_opacity[coll_id * 7 + 2];
+			collected_conic_d[block.thread_rank()] = conic_opacity[coll_id * 7 + 3];
+			collected_conic_e[block.thread_rank()] = conic_opacity[coll_id * 7 + 4];
+			collected_conic_f[block.thread_rank()] = conic_opacity[coll_id * 7 + 5];
+			collected_o[block.thread_rank()] = conic_opacity[coll_id * 7 + 6];
+		}
+		block.sync();
+		
+		// Iterate over current batch
+		for (int j = 0; !done && j < min(BLOCK3D_SIZE, toDo); j++)
+		{
+			// Keep track of current position in range
+			contributor++;
+			float3 xyz = collected_xyz[j];
+			float3 d = { xyz.x - voxelf.x, xyz.y - voxelf.y, xyz.z - voxelf.z };
+			float conic_a = collected_conic_a[j];
+			float conic_b = collected_conic_b[j];
+			float conic_c = collected_conic_c[j];
+			float conic_d = collected_conic_d[j];
+			float conic_e = collected_conic_e[j];
+			float conic_f = collected_conic_f[j];
+			float opa = collected_o[j];
+
+			float power = - 0.5 * (conic_a * d.x * d.x + conic_d * d.y * d.y + conic_f * d.z * d.z) - conic_b * d.x * d.y - conic_c * d.x * d.z - conic_e * d.y * d.z;
+			
+			// printf("conic_a: %f\n", conic_a);
+			// printf("conic_b: %f\n", conic_b);
+			// printf("conic_c: %f\n", conic_c);
+			// printf("conic_d: %f\n", conic_d);
+			// printf("conic_e: %f\n", conic_e);
+			// printf("conic_f: %f\n", conic_f);
+			// printf("opa: %f\n", opa);
+			// printf("xyz.x: %f, xyz.y: %f, xyz.z: %f\n", xyz.x, xyz.y, xyz.z);
+			// printf("voxelf.x: %f, voxelf.y: %f, voxelf.z: %f\n", voxelf.x, voxelf.y, voxelf.z);
+			// printf("d.x: %f, d.y: %f, d.z: %f\n", d.x, d.y, d.z);
+			// printf("power: %f\n", power);
+
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			#if VOXEL_AXUTILITY_GEO_FORWARD
+				geo += G;
+			#endif
+			float alpha = opa * G;
+			if (alpha < 0.000001f)
+				continue;
+
+			// Simply add all alphas
+			for (int ch = 0; ch < CHANNELS; ch++)
+				C[ch] += alpha;
+			
+			// Keep track of last range entry to update this
+			// pixel.
+			last_contributor = contributor;
+		}
+		
+	}
+
+	// All threads that treat valid pixel write out their final
+	// rendering data to the frame and auxiliary buffers.
+	if (inside)
+	{
+		n_contrib[voxel_id] = last_contributor;
+		for (int ch = 0; ch < CHANNELS; ch++)
+			out_volume[ch * nVoxel_x * nVoxel_y * nVoxel_z + voxel_id] = C[ch];
+		#if VOXEL_AXUTILITY_GEO_FORWARD
+			out_others[GEO_OFFSET * nVoxel_x * nVoxel_y * nVoxel_z + voxel_id] = geo;
+		#endif
+	}
+}
+
+void FORWARD::render(
+	const dim3 grid, dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float3* means3D_norm,
+	const float* conic_opacity,
+	uint32_t* n_contrib,
+	float* out_volume,
+	float* out_others
+	)
+{
+	renderCUDA<NUM_CHANNELS> << <grid, block >> > (
+		ranges,
+		point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		means3D_norm,
+		conic_opacity,
+		n_contrib,
+		out_volume,
+		out_others
+		);
+	
+}
+
+
+void FORWARD::preprocess(int P,
+	const float* means3D,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	int* radii,
+	float3* means3D_norm,
+	float* depths,
+	float* cov3Ds,
+	float* conic_opacity,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered
+	)
+{	
+	preprocessCUDA<NUM_CHANNELS> << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		scales,
+		scale_modifier,
+		rotations,
+		opacities,
+		cov3D_precomp,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		radii,
+		means3D_norm,
+		depths,
+		cov3Ds,
+		conic_opacity,
+		grid,
+		tiles_touched,
+		prefiltered
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/forward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/forward.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef cuda_voxelizer_FORWARD_H_INCLUDED
+#define cuda_voxelizer_FORWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace FORWARD
+{
+	// Perform initial steps for each Gaussian prior to rasterization.
+	void preprocess(int P,
+		const float* orig_points,
+		const glm::vec3* scales,
+		const float scale_modifier,
+		const glm::vec4* rotations,
+		const float* opacities,
+		const float* cov3D_precomp,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+		const float center_x, float center_y, float center_z,
+		int* radii,
+		float3* means3D_norm,
+		float* depths,
+		float* cov3Ds,
+		float* conic_opacity,
+		const dim3 grid,
+		uint32_t* tiles_touched,
+		bool prefiltered
+		);
+
+	// Main rasterization method.
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float3* means3D_norm,
+		const float* conic_opacity,
+		uint32_t* n_contrib,
+		float* out_volume,
+		float* out_others
+		);
+}
+
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/voxelizer.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/voxelizer.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef cuda_voxelizer_H_INCLUDED
+#define cuda_voxelizer_H_INCLUDED
+
+#include <vector>
+#include <functional>
+
+namespace CudaVoxelizer
+{
+    class Voxelizer
+	{
+	public:
+
+		static int forward(
+			std::function<char* (size_t)> geometryBuffer,
+			std::function<char* (size_t)> binningBuffer,
+			std::function<char* (size_t)> imageBuffer,
+			const int P,
+			const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+			const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+			const float center_x, float center_y, float center_z,
+			const float* means3D,
+			const float* opacities,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const bool prefiltered,
+			float* out_volume,
+			float* out_others,
+			int* radii = nullptr,
+			bool debug = false);
+
+		static void backward(
+			const int P, int R, 
+			const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+			const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+			const float center_x, float center_y, float center_z,
+			const float* means3D,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const int* radii,
+			char* geom_buffer,
+			char* binning_buffer,
+			char* img_buffer,
+			const float* dL_dpix,
+			const float* dL_dothers,
+			float* dL_dmean3D_norm,
+			float* dL_dconic3D,
+			float* dL_dopacity,
+			float* dL_dmean3D,
+			float* dL_dcov3D,
+			float* dL_dscale,
+			float* dL_drot,
+			bool debug);
+	};
+
+};
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/voxelizer_impl.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/voxelizer_impl.cu
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "voxelizer_impl.h"
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+#include "auxiliary.h"
+#include "forward.h"
+#include "backward.h"
+
+// Helper function to find the next-highest bit of the MSB
+// on the CPU.
+uint32_t getHigherMsb2(uint32_t n)
+{
+	uint32_t msb = sizeof(n) * 4;
+	uint32_t step = msb;
+	while (step > 1)
+	{
+		step /= 2;
+		if (n >> msb)
+			msb += step;
+		else
+			msb -= step;
+	}
+	if (n >> msb)
+		msb++;
+	return msb;
+}
+
+// Generates one key/value pair for all Gaussian / tile overlaps. 
+// Run once per Gaussian (1:N mapping).
+__global__ void duplicateWithKeys2(
+	int P,
+	const float3* points_xyz_vol,
+	const float* depths,
+	const uint32_t* offsets,
+	uint64_t* gaussian_keys_unsorted,
+	uint32_t* gaussian_values_unsorted,
+	int* radii,
+	dim3 grid)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	// Generate no key/value pair for invisible Gaussians
+	if (radii[idx] > 0)
+	{
+		// Find this Gaussian's offset in buffer for writing keys/values.
+		uint32_t off = (idx == 0) ? 0 : offsets[idx - 1];
+		uint3 cube_min, cube_max;
+
+		getCube(points_xyz_vol[idx], radii[idx], cube_min, cube_max, grid);
+
+		// For each tile that the bounding rect overlaps, emit a 
+		// key/value pair. The key is |  tile ID  |      depth      |,
+		// and the value is the ID of the Gaussian. Sorting the values 
+		// with this key yields Gaussian IDs in a list, such that they
+		// are first sorted by tile and then by depth. 
+		for (int z = cube_min.z; z < cube_max.z; z++)
+		{
+			for (int y = cube_min.y; y < cube_max.y; y++)
+			{
+				for (int x = cube_min.x; x < cube_max.x; x++)
+				{
+					uint64_t key = z * grid.y * grid.x + y * grid.x + x;
+					key <<= 32;
+					key |= *((uint32_t*)&depths[idx]);
+					gaussian_keys_unsorted[off] = key;
+					gaussian_values_unsorted[off] = idx;
+					off++;
+				}
+			}
+		}
+		
+	}
+}
+
+// Check keys to see if it is at the start/end of one tile's range in 
+// the full sorted list. If yes, write start/end of this tile. 
+// Run once per instanced (duplicated) Gaussian ID.
+__global__ void identifyTileRanges2(int L, uint64_t* point_list_keys, uint2* ranges)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= L)
+		return;
+
+	// Read tile ID from key. Update start/end of tile range if at limit.
+	uint64_t key = point_list_keys[idx];
+	uint32_t currtile = key >> 32;
+	if (idx == 0)
+		ranges[currtile].x = 0;
+	else
+	{
+		uint32_t prevtile = point_list_keys[idx - 1] >> 32;
+		if (currtile != prevtile)
+		{
+			ranges[prevtile].y = idx;
+			ranges[currtile].x = idx;
+		}
+	}
+	if (idx == L - 1)
+		ranges[currtile].y = L;
+}
+
+CudaVoxelizer::GeometryState CudaVoxelizer::GeometryState::fromChunk(char*& chunk, size_t P)
+{
+	GeometryState geom;
+	obtain(chunk, geom.depths, P, 128);
+	obtain(chunk, geom.internal_radii, P, 128);
+	obtain(chunk, geom.means3D_norm, P, 128);
+	obtain(chunk, geom.cov3D, P * 6, 128);
+	obtain(chunk, geom.conic_opacity, P * 7, 128);
+	obtain(chunk, geom.tiles_touched, P, 128);
+	cub::DeviceScan::InclusiveSum(nullptr, geom.scan_size, geom.tiles_touched, geom.tiles_touched, P);
+	obtain(chunk, geom.scanning_space, geom.scan_size, 128);
+	obtain(chunk, geom.point_offsets, P, 128);
+	return geom;
+}
+
+CudaVoxelizer::ImageState CudaVoxelizer::ImageState::fromChunk(char*& chunk, size_t N)
+{
+	ImageState img;
+	obtain(chunk, img.n_contrib, N, 128);
+	obtain(chunk, img.ranges, N, 128);
+	return img;
+}
+
+
+CudaVoxelizer::BinningState CudaVoxelizer::BinningState::fromChunk(char*& chunk, size_t P)
+{
+	BinningState binning;
+	obtain(chunk, binning.point_list, P, 128);
+	obtain(chunk, binning.point_list_unsorted, P, 128);
+	obtain(chunk, binning.point_list_keys, P, 128);
+	obtain(chunk, binning.point_list_keys_unsorted, P, 128);
+	cub::DeviceRadixSort::SortPairs(
+		nullptr, binning.sorting_size,
+		binning.point_list_keys_unsorted, binning.point_list_keys,
+		binning.point_list_unsorted, binning.point_list, P);
+	obtain(chunk, binning.list_sorting_space, binning.sorting_size, 128);
+	return binning;
+}
+
+int CudaVoxelizer::Voxelizer::forward(
+	std::function<char* (size_t)> geometryBuffer,
+	std::function<char* (size_t)> binningBuffer,
+	std::function<char* (size_t)> imageBuffer,
+	const int P, 
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float* means3D,
+	const float* opacities,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const bool prefiltered,
+	float* out_volume,
+	float* out_others,
+	int* radii,
+	bool debug)
+{
+
+	size_t chunk_size = required<GeometryState>(P);
+	char* chunkptr = geometryBuffer(chunk_size);
+	GeometryState geomState = GeometryState::fromChunk(chunkptr, P);
+	
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X, (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y, (nVoxel_z + BLOCK3D_Z - 1) / BLOCK3D_Z);
+	dim3 block(BLOCK3D_X, BLOCK3D_Y, BLOCK3D_Z);
+
+	// Dynamically resize image-based auxiliary buffers during training
+	size_t img_chunk_size = required<ImageState>(nVoxel_x * nVoxel_y * nVoxel_z);
+	char* img_chunkptr = imageBuffer(img_chunk_size);
+	ImageState imgState = ImageState::fromChunk(img_chunkptr, nVoxel_x * nVoxel_y * nVoxel_z);
+	
+
+	CHECK_CUDA(FORWARD::preprocess(
+		P,
+		means3D,
+		(glm::vec3*)scales,
+		scale_modifier,
+		(glm::vec4*)rotations,
+		opacities,
+		cov3D_precomp,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		radii,
+		geomState.means3D_norm,
+		geomState.depths,
+		geomState.cov3D,
+		geomState.conic_opacity,
+		tile_grid,
+		geomState.tiles_touched,
+		prefiltered
+	), debug);
+
+	// Compute prefix sum over full list of touched tile counts by Gaussians
+	// E.g., [2, 3, 0, 2, 1] -> [2, 5, 5, 7, 8]
+	CHECK_CUDA(cub::DeviceScan::InclusiveSum(geomState.scanning_space, geomState.scan_size, geomState.tiles_touched, geomState.point_offsets, P), debug);
+
+	// Retrieve total number of Gaussian instances to launch and resize aux buffers
+	int num_rendered;
+	CHECK_CUDA(cudaMemcpy(&num_rendered, geomState.point_offsets + P - 1, sizeof(int), cudaMemcpyDeviceToHost), debug);
+
+	size_t binning_chunk_size = required<BinningState>(num_rendered);
+	char* binning_chunkptr = binningBuffer(binning_chunk_size);
+	BinningState binningState = BinningState::fromChunk(binning_chunkptr, num_rendered);
+
+	// For each instance to be rendered, produce adequate [ tile | depth ] key 
+	// and corresponding dublicated Gaussian indices to be sorted
+	duplicateWithKeys2 << <(P + 255) / 256, 256 >> > (
+		P,
+		geomState.means3D_norm,
+		geomState.depths,
+		geomState.point_offsets,
+		binningState.point_list_keys_unsorted,
+		binningState.point_list_unsorted,
+		radii,
+		tile_grid)
+	CHECK_CUDA(, debug)
+
+	int bit = getHigherMsb2(tile_grid.x * tile_grid.y * tile_grid.z);
+
+	// Sort complete list of (duplicated) Gaussian indices by keys
+	CHECK_CUDA(cub::DeviceRadixSort::SortPairs(
+		binningState.list_sorting_space,
+		binningState.sorting_size,
+		binningState.point_list_keys_unsorted, binningState.point_list_keys,
+		binningState.point_list_unsorted, binningState.point_list,
+		num_rendered, 0, 32 + bit), debug)
+
+	CHECK_CUDA(cudaMemset(imgState.ranges, 0, tile_grid.x * tile_grid.y * tile_grid.z * sizeof(uint2)), debug);
+
+	// Identify start and end of per-tile workloads in sorted list
+	if (num_rendered > 0)
+		identifyTileRanges2 << <(num_rendered + 255) / 256, 256 >> > (
+			num_rendered,
+			binningState.point_list_keys,
+			imgState.ranges);
+	CHECK_CUDA(, debug)
+
+	// Let each tile blend its range of Gaussians independently in parallel
+	CHECK_CUDA(FORWARD::render(
+		tile_grid, block,
+		imgState.ranges,
+		binningState.point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		geomState.means3D_norm,
+		geomState.conic_opacity,
+		imgState.n_contrib,
+		out_volume,
+		out_others
+		), debug)
+
+	
+    return num_rendered;
+}
+
+
+// Produce necessary gradients for optimization, corresponding
+// to forward render pass
+void CudaVoxelizer::Voxelizer::backward(
+	const int P, int R, 
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float* means3D,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const int* radii,
+	char* geom_buffer,
+	char* binning_buffer,
+	char* img_buffer,
+	const float* dL_dpix,
+	const float* dL_dothers,
+	float* dL_dmean3D_norm,
+	float* dL_dconic3D,
+	float* dL_dopacity,
+	float* dL_dmean3D,
+	float* dL_dcov3D,
+	float* dL_dscale,
+	float* dL_drot,
+	bool debug)
+{
+	GeometryState geomState = GeometryState::fromChunk(geom_buffer, P);
+	BinningState binningState = BinningState::fromChunk(binning_buffer, R);
+	ImageState imgState = ImageState::fromChunk(img_buffer, nVoxel_x * nVoxel_y * nVoxel_z);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X, (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y, (nVoxel_z + BLOCK3D_Z - 1) / BLOCK3D_Z);
+	dim3 block(BLOCK3D_X, BLOCK3D_Y, BLOCK3D_Z);
+
+	// Compute loss gradients w.r.t. 3D mean position, conic matrix,
+	// opacity.
+	CHECK_CUDA(BACKWARD::render(
+		tile_grid,
+		block,
+		imgState.ranges,
+		binningState.point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		geomState.means3D_norm,
+		geomState.conic_opacity,
+		imgState.n_contrib,
+		dL_dpix,
+		dL_dothers,
+		(float3*)dL_dmean3D_norm,
+		dL_dconic3D,
+		dL_dopacity), debug)
+
+	const float* cov3D_ptr = (cov3D_precomp != nullptr) ? cov3D_precomp : geomState.cov3D;
+	CHECK_CUDA(BACKWARD::preprocess(P, 
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		cov3D_ptr,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		(float3*)dL_dmean3D_norm,
+		dL_dconic3D,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		(glm::vec3*)dL_dscale,
+		(glm::vec4*)dL_drot), debug)
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/voxelizer_impl.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/cuda_voxelizer/voxelizer_impl.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include "voxelizer.h"
+#include <cuda_runtime_api.h>
+
+
+namespace CudaVoxelizer
+{
+	template <typename T>
+	static void obtain(char*& chunk, T*& ptr, std::size_t count, std::size_t alignment)
+	{
+		std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
+		ptr = reinterpret_cast<T*>(offset);
+		chunk = reinterpret_cast<char*>(ptr + count);
+	}
+
+	struct GeometryState
+	{
+		size_t scan_size;
+		float* depths;
+		char* scanning_space;
+		int* internal_radii;
+		float3* means3D_norm;
+		float* cov3D;
+		float* conic_opacity;
+		uint32_t* point_offsets;
+		uint32_t* tiles_touched;
+
+		static GeometryState fromChunk(char*& chunk, size_t P);
+	};
+
+	struct ImageState
+	{
+		uint2* ranges;
+		uint32_t* n_contrib;
+
+		static ImageState fromChunk(char*& chunk, size_t N);
+	};
+
+	struct BinningState
+	{
+		size_t sorting_size;
+		uint64_t* point_list_keys_unsorted;
+		uint64_t* point_list_keys;
+		uint32_t* point_list_unsorted;
+		uint32_t* point_list;
+		char* list_sorting_space;
+
+		static BinningState fromChunk(char*& chunk, size_t P);
+	};
+
+	template<typename T> 
+	size_t required(size_t P)
+	{
+		char* size = nullptr;
+		T::fromChunk(size, P);
+		return ((size_t)size) + 128;
+	}
+};

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/diff_Xray_gaussian_rasterization_voxelization_legacy/__init__.py
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/diff_Xray_gaussian_rasterization_voxelization_legacy/__init__.py
@@ -1,0 +1,490 @@
+#
+# Copyright (C) 2023, Inria
+# GRAPHDECO research group, https://team.inria.fr/graphdeco
+# All rights reserved.
+#
+# This software is free for non-commercial, research and evaluation use
+# under the terms of the LICENSE.md file.
+#
+# For inquiries contact  george.drettakis@inria.fr
+#
+
+from typing import NamedTuple
+import torch.nn as nn
+import torch
+from . import _C
+import copy
+
+
+def cpu_deep_copy_tuple(input_tuple):
+    copied_tensors = [
+        item.cpu().clone() if isinstance(item, torch.Tensor) else item
+        for item in input_tuple
+    ]
+    return tuple(copied_tensors)
+
+
+def rasterize_gaussians(
+    means3D,
+    means2D,
+    opacities,
+    dummy_opacities,
+    scales,
+    rotations,
+    cov3Ds_precomp,
+    raster_settings,
+):
+    return _RasterizeGaussians.apply(
+        means3D,
+        means2D,
+        opacities,
+        dummy_opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        raster_settings,
+    )
+
+
+class _RasterizeGaussians(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        means3D,
+        means2D,
+        opacities,
+        dummy_opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        raster_settings,
+    ):
+
+        # Restructure arguments the way that the C++ lib expects them
+        args = (
+            means3D,
+            opacities,
+            scales,
+            rotations,
+            raster_settings.scale_modifier,
+            cov3Ds_precomp,
+            raster_settings.viewmatrix,
+            raster_settings.projmatrix,
+            raster_settings.tanfovx,
+            raster_settings.tanfovy,
+            raster_settings.image_height,
+            raster_settings.image_width,
+            raster_settings.campos,
+            raster_settings.prefiltered,
+            raster_settings.mode,
+            raster_settings.debug,
+        )
+
+        # Invoke C++/CUDA rasterizer
+        if raster_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                num_rendered, color, render_others, radii, geomBuffer, binningBuffer, imgBuffer = (
+                    _C.rasterize_gaussians(*args)
+                )
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_fw.dump")
+                print(
+                    "\nAn error occured in forward. Please forward snapshot_fw.dump for debugging."
+                )
+                raise ex
+        else:
+            num_rendered, color, render_others, radii, geomBuffer, binningBuffer, imgBuffer = (
+                _C.rasterize_gaussians(*args)
+            )
+
+        # Keep relevant tensors for backward
+        ctx.raster_settings = raster_settings
+        ctx.num_rendered = num_rendered
+        ctx.mode = raster_settings.mode
+        ctx.save_for_backward(
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        )
+        return color, radii, render_others
+
+    @staticmethod
+    def backward(ctx, grad_out_color, grad_radii, grad_others):
+
+        # Restore necessary values from context
+        num_rendered = ctx.num_rendered
+        raster_settings = ctx.raster_settings
+        mode = ctx.mode
+        (
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        ) = ctx.saved_tensors
+
+        # Restructure args as C++ method expects them
+        args = (
+            means3D,
+            radii,
+            scales,
+            rotations,
+            raster_settings.scale_modifier,
+            cov3Ds_precomp,
+            raster_settings.viewmatrix,
+            raster_settings.projmatrix,
+            raster_settings.tanfovx,
+            raster_settings.tanfovy,
+            grad_out_color,
+            raster_settings.campos,
+            geomBuffer,
+            num_rendered,
+            binningBuffer,
+            imgBuffer,
+            mode,
+            raster_settings.debug,
+        )
+
+        # Compute gradients for relevant tensors by invoking backward method
+        if raster_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                (
+                    grad_means2D,
+                    grad_opacities,
+                    grad_eta,  # grad_eta
+                    grad_means3D,
+                    grad_cov3Ds_precomp,
+                    grad_scales,
+                    grad_rotations,
+                ) = _C.rasterize_gaussians_backward(*args)
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_bw.dump")
+                print(
+                    "\nAn error occured in backward. Writing snapshot_bw.dump for debugging.\n"
+                )
+                raise ex
+        else:
+            (
+                grad_means2D,
+                grad_opacities,
+                grad_eta,
+                grad_means3D,
+                grad_cov3Ds_precomp,
+                grad_scales,
+                grad_rotations,
+            ) = _C.rasterize_gaussians_backward(*args)
+        grad_dummy_opacities = copy.deepcopy(grad_opacities)
+        grads = (
+            grad_means3D,
+            grad_means2D,
+            grad_opacities,
+            grad_dummy_opacities,
+            grad_scales,
+            grad_rotations,
+            grad_cov3Ds_precomp,
+            None,
+        )
+
+        return grads
+
+
+# Change according to line 45 gaussian_renderer/__init__.py
+class GaussianRasterizationSettings(NamedTuple):
+    image_height: int
+    image_width: int
+    tanfovx: float
+    tanfovy: float
+    scale_modifier: float
+    viewmatrix: torch.Tensor
+    projmatrix: torch.Tensor
+    campos: torch.Tensor
+    prefiltered: bool
+    mode: int
+    debug: bool
+
+
+class GaussianRasterizer(nn.Module):
+    def __init__(self, raster_settings):
+        super().__init__()
+        self.raster_settings = raster_settings
+
+    def markVisible(self, positions):
+        # Mark visible points (based on frustum culling for camera) with a boolean
+        with torch.no_grad():
+            raster_settings = self.raster_settings
+            visible = _C.mark_visible(
+                positions, raster_settings.viewmatrix, raster_settings.projmatrix
+            )
+
+        return visible
+
+    def forward(
+        self,
+        means3D,
+        means2D,
+        opacities,
+        dummy_opacities,
+        scales=None,
+        rotations=None,
+        cov3D_precomp=None,
+    ):
+
+        raster_settings = self.raster_settings
+
+        if ((scales is None or rotations is None) and cov3D_precomp is None) or (
+            (scales is not None or rotations is not None) and cov3D_precomp is not None
+        ):
+            raise Exception(
+                "Please provide exactly one of either scale/rotation pair or precomputed 3D covariance!"
+            )
+
+        if scales is None:
+            scales = torch.Tensor([])
+        if rotations is None:
+            rotations = torch.Tensor([])
+        if cov3D_precomp is None:
+            cov3D_precomp = torch.Tensor([])
+
+        # Invoke C++/CUDA rasterization routine
+        return rasterize_gaussians(
+            means3D,
+            means2D,
+            opacities,
+            dummy_opacities,
+            scales,
+            rotations,
+            cov3D_precomp,
+            raster_settings,
+        )
+
+
+class GaussianVoxelizationSettings(NamedTuple):
+    scale_modifier: float
+    nVoxel_x: int
+    nVoxel_y: int
+    nVoxel_z: int
+    sVoxel_x: float
+    sVoxel_y: float
+    sVoxel_z: float
+    center_x: float
+    center_y: float
+    center_z: float
+    prefiltered: bool
+    debug: bool
+
+
+def voxelize_gaussians(
+    means3D, opacities, scales, rotations, cov3Ds_precomp, voxel_settings
+):
+    return _VoxelizeGaussians.apply(
+        means3D,
+        opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        voxel_settings,
+    )
+
+
+class _VoxelizeGaussians(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        means3D,
+        opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        voxel_settings,
+    ):
+        # Restructure arguments the way that the C++ lib expects them
+        args = (
+            means3D,
+            opacities,
+            scales,
+            rotations,
+            voxel_settings.scale_modifier,
+            cov3Ds_precomp,
+            voxel_settings.nVoxel_x,
+            voxel_settings.nVoxel_y,
+            voxel_settings.nVoxel_z,
+            voxel_settings.sVoxel_x,
+            voxel_settings.sVoxel_y,
+            voxel_settings.sVoxel_z,
+            voxel_settings.center_x,
+            voxel_settings.center_y,
+            voxel_settings.center_z,
+            voxel_settings.prefiltered,
+            voxel_settings.debug,
+        )
+
+        # Invoke C++/CUDA rasterizer
+        if voxel_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                num_rendered, color, voxel_others, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+                # num_rendered, color, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_fw.dump")
+                print(
+                    "\nAn error occured in forward. Please forward snapshot_fw.dump for debugging."
+                )
+                raise ex
+        else:
+            num_rendered, color, voxel_others, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+            # num_rendered, color, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+
+        # Keep relevant tensors for backward
+        ctx.voxel_settings = voxel_settings
+        ctx.num_rendered = num_rendered
+        ctx.save_for_backward(
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        )
+
+        return color, radii, voxel_others
+        # return color, radii
+
+    @staticmethod
+    def backward(ctx, grad_out_color, grad_radii, grad_others):
+    # def backward(ctx, grad_out_color, grad_radii):
+
+        # Restore necessary values from context
+        num_rendered = ctx.num_rendered
+        voxel_settings = ctx.voxel_settings
+        (
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        ) = ctx.saved_tensors
+
+        args = (
+            means3D,
+            radii,
+            scales,
+            rotations,
+            voxel_settings.scale_modifier,
+            cov3Ds_precomp,
+            grad_out_color,
+            grad_others,
+            geomBuffer,
+            num_rendered,
+            binningBuffer,
+            imgBuffer,
+            voxel_settings.nVoxel_x,
+            voxel_settings.nVoxel_y,
+            voxel_settings.nVoxel_z,
+            voxel_settings.sVoxel_x,
+            voxel_settings.sVoxel_y,
+            voxel_settings.sVoxel_z,
+            voxel_settings.center_x,
+            voxel_settings.center_y,
+            voxel_settings.center_z,
+            voxel_settings.debug,
+        )
+
+        # Compute gradients for relevant tensors by invoking backward method
+        if voxel_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                (
+                    grad_opacities,
+                    grad_means3D,
+                    grad_cov3Ds_precomp,
+                    grad_scales,
+                    grad_rotations,
+                ) = _C.voxelize_gaussians_backward(*args)
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_bw.dump")
+                print(
+                    "\nAn error occured in backward. Writing snapshot_bw.dump for debugging.\n"
+                )
+                raise ex
+        else:
+            (
+                grad_opacities,
+                grad_means3D,
+                grad_cov3Ds_precomp,
+                grad_scales,
+                grad_rotations,
+            ) = _C.voxelize_gaussians_backward(*args)
+        grads = (
+            grad_means3D,
+            grad_opacities,
+            grad_scales,
+            grad_rotations,
+            grad_cov3Ds_precomp,
+            None,
+        )
+
+        return grads
+
+
+class GaussianVoxelizer(nn.Module):
+    def __init__(self, voxel_settings):
+        super().__init__()
+        self.voxel_settings = voxel_settings
+
+    def forward(
+        self,
+        means3D,
+        opacities,
+        scales=None,
+        rotations=None,
+        cov3D_precomp=None,
+    ):
+
+        voxel_settings = self.voxel_settings
+
+        if ((scales is None or rotations is None) and cov3D_precomp is None) or (
+            (scales is not None or rotations is not None) and cov3D_precomp is not None
+        ):
+            raise Exception(
+                "Please provide exactly one of either scale/rotation pair or precomputed 3D covariance!"
+            )
+
+        if scales is None:
+            scales = torch.Tensor([])
+        if rotations is None:
+            rotations = torch.Tensor([])
+        if cov3D_precomp is None:
+            cov3D_precomp = torch.Tensor([])
+
+        # Invoke C++/CUDA rasterization routine
+        return voxelize_gaussians(
+            means3D,
+            opacities,
+            scales,
+            rotations,
+            cov3D_precomp,
+            voxel_settings,
+        )

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/ext.cpp
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/ext.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <torch/extension.h>
+#include "rasterize_points.h"
+#include "voxelize_points.h"
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("rasterize_gaussians", &RasterizeGaussiansCUDA);
+  m.def("rasterize_gaussians_backward", &RasterizeGaussiansBackwardCUDA);
+  m.def("voxelize_gaussians", &VoxelizeGaussiansCUDA);
+  m.def("voxelize_gaussians_backward", &VoxelizeGaussiansBackwardCUDA);
+  m.def("mark_visible", &markVisible);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/rasterize_points.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/rasterize_points.cu
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <math.h>
+#include <torch/extension.h>
+#include <cstdio>
+#include <sstream>
+#include <iostream>
+#include <tuple>
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include <memory>
+#include "cuda_rasterizer/config.h"
+#include "cuda_rasterizer/rasterizer.h"
+#include <fstream>
+#include <string>
+#include <functional>
+
+std::function<char*(size_t N)> resizeFunctional(torch::Tensor& t) {
+    auto lambda = [&t](size_t N) {
+        t.resize_({(long long)N});
+		return reinterpret_cast<char*>(t.contiguous().data_ptr());
+    };
+    return lambda;
+}
+
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+RasterizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+	const torch::Tensor& projmatrix,
+	const float tan_fovx, 
+	const float tan_fovy,
+    const int image_height,
+    const int image_width,
+	const torch::Tensor& campos,
+	const bool prefiltered,
+	const int mode,  // Scanner mode (0: parallel beam, 1: cone beam)
+	const bool debug)
+{
+  if (means3D.ndimension() != 2 || means3D.size(1) != 3) {
+    AT_ERROR("means3D must have dimensions (num_points, 3)");
+  }
+  
+  const int P = means3D.size(0);
+  const int H = image_height;
+  const int W = image_width;
+
+  auto int_opts = means3D.options().dtype(torch::kInt32);
+  auto float_opts = means3D.options().dtype(torch::kFloat32);
+
+  torch::Tensor out_color = torch::full({NUM_CHANNELS, H, W}, 0.0, float_opts);
+  torch::Tensor out_others = torch::full({NUM_OTHERS, H, W}, 0.0, float_opts);
+  torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
+  
+  torch::Device device(torch::kCUDA);
+  torch::TensorOptions options(torch::kByte);
+  torch::Tensor geomBuffer = torch::empty({0}, options.device(device));
+  torch::Tensor binningBuffer = torch::empty({0}, options.device(device));
+  torch::Tensor imgBuffer = torch::empty({0}, options.device(device));
+  std::function<char*(size_t)> geomFunc = resizeFunctional(geomBuffer);
+  std::function<char*(size_t)> binningFunc = resizeFunctional(binningBuffer);
+  std::function<char*(size_t)> imgFunc = resizeFunctional(imgBuffer);
+  
+  int rendered = 0;
+  if(P != 0)
+  {
+	rendered = CudaRasterizer::Rasterizer::forward(
+	    geomFunc,
+		binningFunc,
+		imgFunc,
+	    P, 
+		W, H,
+		means3D.contiguous().data<float>(),
+		opacity.contiguous().data<float>(), 
+		scales.contiguous().data_ptr<float>(),
+		scale_modifier,
+		rotations.contiguous().data_ptr<float>(),
+		cov3D_precomp.contiguous().data<float>(), 
+		viewmatrix.contiguous().data<float>(), 
+		projmatrix.contiguous().data<float>(),
+		campos.contiguous().data<float>(),
+		tan_fovx,
+		tan_fovy,
+		prefiltered,
+		mode,
+		out_color.contiguous().data<float>(),
+		out_others.contiguous().data<float>(),
+		radii.contiguous().data<int>(),
+		debug);
+  }
+  return std::make_tuple(rendered, out_color, out_others, radii, geomBuffer, binningBuffer, imgBuffer);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+ RasterizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+    const torch::Tensor& projmatrix,
+	const float tan_fovx,
+	const float tan_fovy,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& campos,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int mode,
+	const bool debug) 
+{
+  const int P = means3D.size(0);
+  const int H = dL_dout_color.size(1);
+  const int W = dL_dout_color.size(2);
+  
+  torch::Tensor dL_dmeans3D = torch::zeros({P, 3}, means3D.options());
+  torch::Tensor dL_dmeans2D = torch::zeros({P, 3}, means3D.options());
+  torch::Tensor dL_dconic = torch::zeros({P, 2, 2}, means3D.options());
+  torch::Tensor dL_dopacity = torch::zeros({P, 1}, means3D.options());
+  torch::Tensor dL_deta = torch::zeros({P, 1}, means3D.options()); 
+  torch::Tensor dL_dcov3D = torch::zeros({P, 6}, means3D.options());
+  torch::Tensor dL_dscales = torch::zeros({P, 3}, means3D.options());
+  torch::Tensor dL_drotations = torch::zeros({P, 4}, means3D.options());
+  
+  if(P != 0)
+  {   
+	  CudaRasterizer::Rasterizer::backward(P, R,
+	  W, H, 
+	  means3D.contiguous().data<float>(),
+	  scales.data_ptr<float>(),
+	  scale_modifier,
+	  rotations.data_ptr<float>(),
+	  cov3D_precomp.contiguous().data<float>(),
+	  viewmatrix.contiguous().data<float>(),
+	  projmatrix.contiguous().data<float>(),
+	  campos.contiguous().data<float>(),
+	  tan_fovx,
+	  tan_fovy,
+	  radii.contiguous().data<int>(),
+	  reinterpret_cast<char*>(geomBuffer.contiguous().data_ptr()),
+	  reinterpret_cast<char*>(binningBuffer.contiguous().data_ptr()),
+	  reinterpret_cast<char*>(imageBuffer.contiguous().data_ptr()),
+	  dL_dout_color.contiguous().data<float>(),
+	  dL_dmeans2D.contiguous().data<float>(),
+	  dL_dconic.contiguous().data<float>(),  
+	  dL_dopacity.contiguous().data<float>(),
+	  dL_deta.contiguous().data<float>(),
+	  dL_dmeans3D.contiguous().data<float>(),
+	  dL_dcov3D.contiguous().data<float>(),
+	  dL_dscales.contiguous().data<float>(),
+	  dL_drotations.contiguous().data<float>(),
+	  mode,
+	  debug);
+  }
+  return std::make_tuple(dL_dmeans2D, dL_dopacity, dL_deta, dL_dmeans3D, dL_dcov3D, dL_dscales, dL_drotations);
+}
+
+torch::Tensor markVisible(
+		torch::Tensor& means3D,
+		torch::Tensor& viewmatrix,
+		torch::Tensor& projmatrix)
+{ 
+  const int P = means3D.size(0);
+  
+  torch::Tensor present = torch::full({P}, false, means3D.options().dtype(at::kBool));
+ 
+  if(P != 0)
+  {
+	CudaRasterizer::Rasterizer::markVisible(P,
+		means3D.contiguous().data<float>(),
+		viewmatrix.contiguous().data<float>(),
+		projmatrix.contiguous().data<float>(),
+		present.contiguous().data<bool>());
+  }
+  
+  return present;
+}
+

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/rasterize_points.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/rasterize_points.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+#include <torch/extension.h>
+#include <cstdio>
+#include <tuple>
+#include <string>
+
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+RasterizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+	const torch::Tensor& projmatrix,
+	const float tan_fovx, 
+	const float tan_fovy,
+    const int image_height,
+    const int image_width,
+	const torch::Tensor& campos,
+	const bool prefiltered,
+	const int mode,
+	const bool debug);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+RasterizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+    const torch::Tensor& projmatrix,
+	const float tan_fovx, 
+	const float tan_fovy,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& campos,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int mode,
+	const bool debug);
+		
+torch::Tensor markVisible(
+		torch::Tensor& means3D,
+		torch::Tensor& viewmatrix,
+		torch::Tensor& projmatrix);
+

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/setup.py
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/setup.py
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2023, Inria
+# GRAPHDECO research group, https://team.inria.fr/graphdeco
+# All rights reserved.
+#
+# This software is free for non-commercial, research and evaluation use
+# under the terms of the LICENSE.md file.
+#
+# For inquiries contact  george.drettakis@inria.fr
+#
+
+from setuptools import setup
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+import os
+
+os.path.dirname(os.path.abspath(__file__))
+
+setup(
+    name="diff_Xray_gaussian_rasterization_voxelization_legacy",
+    packages=["diff_Xray_gaussian_rasterization_voxelization_legacy"],
+    ext_modules=[
+        CUDAExtension(
+            name="diff_Xray_gaussian_rasterization_voxelization_legacy._C",
+            sources=[
+                "cuda_rasterizer/rasterizer_impl.cu",
+                "cuda_rasterizer/forward.cu",
+                "cuda_rasterizer/backward.cu",
+                "rasterize_points.cu",
+                "cuda_voxelizer/voxelizer_impl.cu",
+                "cuda_voxelizer/forward.cu",
+                "cuda_voxelizer/backward.cu",
+                "voxelize_points.cu",
+                "ext.cpp",
+            ],
+            extra_compile_args={
+                "nvcc": [
+                    "-I"
+                    + os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)),
+                        "../diff-Xray-gaussian-rasterization-voxelization/third_party/glm/",
+                    )
+                ]
+            },
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/voxelize_points.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/voxelize_points.cu
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <math.h>
+#include <torch/extension.h>
+#include <cstdio>
+#include <sstream>
+#include <iostream>
+#include <tuple>
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include <memory>
+#include "cuda_voxelizer/config.h"
+#include "cuda_voxelizer/voxelizer.h"
+#include <fstream>
+#include <string>
+#include <functional>
+
+
+std::function<char*(size_t N)> resizeFunctional2(torch::Tensor& t) {
+    auto lambda = [&t](size_t N) {
+        t.resize_({(long long)N});
+		return reinterpret_cast<char*>(t.contiguous().data_ptr());
+    };
+    return lambda;
+}
+
+// std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool prefiltered,
+	const bool debug)
+{
+	if (means3D.ndimension() != 2 || means3D.size(1) != 3) {
+		AT_ERROR("means3D must have dimensions (num_points, 3)");
+	}
+
+	const int P = means3D.size(0);
+
+    auto int_opts = means3D.options().dtype(torch::kInt32);
+    auto float_opts = means3D.options().dtype(torch::kFloat32);
+
+	torch::Tensor out_volume = torch::full({nVoxel_x, nVoxel_y, nVoxel_z}, 0.0, float_opts);
+	torch::Tensor out_others = torch::full({nVoxel_x, nVoxel_y, nVoxel_z}, 0.0, float_opts);
+	torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
+	
+	torch::Device device(torch::kCUDA);
+	torch::TensorOptions options(torch::kByte);
+	torch::Tensor geomBuffer = torch::empty({0}, options.device(device));
+	torch::Tensor binningBuffer = torch::empty({0}, options.device(device));
+	torch::Tensor imgBuffer = torch::empty({0}, options.device(device));
+	std::function<char*(size_t)> geomFunc = resizeFunctional2(geomBuffer);
+	std::function<char*(size_t)> binningFunc = resizeFunctional2(binningBuffer);
+	std::function<char*(size_t)> imgFunc = resizeFunctional2(imgBuffer);
+	
+	int rendered = 0;
+	if(P != 0)
+  	{
+		rendered = CudaVoxelizer::Voxelizer::forward(
+            geomFunc,
+            binningFunc,
+			imgFunc,
+            P, 
+			nVoxel_x, nVoxel_y, nVoxel_z,
+			sVoxel_x, sVoxel_y, sVoxel_z,
+			center_x, center_y, center_z,
+            means3D.contiguous().data<float>(),
+            opacity.contiguous().data<float>(), 
+            scales.contiguous().data_ptr<float>(),
+            scale_modifier,
+            rotations.contiguous().data_ptr<float>(),
+            cov3D_precomp.contiguous().data<float>(), 
+            prefiltered,
+            out_volume.contiguous().data<float>(),
+			out_others.contiguous().data<float>(),
+            radii.contiguous().data<int>(),
+            debug);
+	}
+
+	return std::make_tuple(rendered, out_volume, out_others, radii, geomBuffer, binningBuffer, imgBuffer);
+	// return std::make_tuple(rendered, out_volume, radii, geomBuffer, binningBuffer, imgBuffer);
+}
+
+
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& dL_dout_others,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool debug)
+{
+	const int P = means3D.size(0);
+
+	torch::Tensor dL_dmeans3D = torch::zeros({P, 3}, means3D.options());
+	torch::Tensor dL_dmeans3D_norm = torch::zeros({P, 3}, means3D.options());
+	torch::Tensor dL_dconic3D = torch::zeros({P, 6}, means3D.options());
+	torch::Tensor dL_dopacity = torch::zeros({P, 1}, means3D.options());
+	torch::Tensor dL_dcov3D = torch::zeros({P, 6}, means3D.options());
+	torch::Tensor dL_dscales = torch::zeros({P, 3}, means3D.options());
+	torch::Tensor dL_drotations = torch::zeros({P, 4}, means3D.options());
+
+	if(P != 0)
+	{   
+		CudaVoxelizer::Voxelizer::backward(P, R,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		means3D.contiguous().data<float>(),
+		scales.data_ptr<float>(),
+		scale_modifier,
+		rotations.data_ptr<float>(),
+		cov3D_precomp.contiguous().data<float>(),
+		radii.contiguous().data<int>(),
+		reinterpret_cast<char*>(geomBuffer.contiguous().data_ptr()),
+		reinterpret_cast<char*>(binningBuffer.contiguous().data_ptr()),
+		reinterpret_cast<char*>(imageBuffer.contiguous().data_ptr()),
+		dL_dout_color.contiguous().data<float>(),
+		dL_dout_others.contiguous().data<float>(),
+		dL_dmeans3D_norm.contiguous().data<float>(),  
+		dL_dconic3D.contiguous().data<float>(),  
+		dL_dopacity.contiguous().data<float>(),
+		dL_dmeans3D.contiguous().data<float>(),
+		dL_dcov3D.contiguous().data<float>(),
+		dL_dscales.contiguous().data<float>(),
+		dL_drotations.contiguous().data<float>(),
+		debug);
+	}
+
+	return std::make_tuple(dL_dopacity, dL_dmeans3D, dL_dcov3D, dL_dscales, dL_drotations);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/voxelize_points.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-legacy/voxelize_points.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+#include <torch/extension.h>
+#include <cstdio>
+#include <tuple>
+#include <string>
+
+// std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool prefiltered,
+	const bool debug);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& dL_dout_others,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool debug);

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/LICENSE.md
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/LICENSE.md
@@ -1,0 +1,83 @@
+Gaussian-Splatting License  
+===========================  
+
+**Inria** and **the Max Planck Institut for Informatik (MPII)** hold all the ownership rights on the *Software* named **gaussian-splatting**.  
+The *Software* is in the process of being registered with the Agence pour la Protection des  
+Programmes (APP).  
+
+The *Software* is still being developed by the *Licensor*.  
+
+*Licensor*'s goal is to allow the research community to use, test and evaluate  
+the *Software*.  
+
+## 1.  Definitions  
+
+*Licensee* means any person or entity that uses the *Software* and distributes  
+its *Work*.  
+
+*Licensor* means the owners of the *Software*, i.e Inria and MPII  
+
+*Software* means the original work of authorship made available under this  
+License ie gaussian-splatting.  
+
+*Work* means the *Software* and any additions to or derivative works of the  
+*Software* that are made available under this License.  
+
+
+## 2.  Purpose  
+This license is intended to define the rights granted to the *Licensee* by  
+Licensors under the *Software*.  
+
+## 3.  Rights granted  
+
+For the above reasons Licensors have decided to distribute the *Software*.  
+Licensors grant non-exclusive rights to use the *Software* for research purposes  
+to research users (both academic and industrial), free of charge, without right  
+to sublicense.. The *Software* may be used "non-commercially", i.e., for research  
+and/or evaluation purposes only.  
+
+Subject to the terms and conditions of this License, you are granted a  
+non-exclusive, royalty-free, license to reproduce, prepare derivative works of,  
+publicly display, publicly perform and distribute its *Work* and any resulting  
+derivative works in any form.  
+
+## 4.  Limitations  
+
+**4.1 Redistribution.** You may reproduce or distribute the *Work* only if (a) you do  
+so under this License, (b) you include a complete copy of this License with  
+your distribution, and (c) you retain without modification any copyright,  
+patent, trademark, or attribution notices that are present in the *Work*.  
+
+**4.2 Derivative Works.** You may specify that additional or different terms apply  
+to the use, reproduction, and distribution of your derivative works of the *Work*  
+("Your Terms") only if (a) Your Terms provide that the use limitation in  
+Section 2 applies to your derivative works, and (b) you identify the specific  
+derivative works that are subject to Your Terms. Notwithstanding Your Terms,  
+this License (including the redistribution requirements in Section 3.1) will  
+continue to apply to the *Work* itself.  
+
+**4.3** Any other use without of prior consent of Licensors is prohibited. Research  
+users explicitly acknowledge having received from Licensors all information  
+allowing to appreciate the adequacy between of the *Software* and their needs and  
+to undertake all necessary precautions for its execution and use.  
+
+**4.4** The *Software* is provided both as a compiled library file and as source  
+code. In case of using the *Software* for a publication or other results obtained  
+through the use of the *Software*, users are strongly encouraged to cite the  
+corresponding publications as explained in the documentation of the *Software*.  
+
+## 5.  Disclaimer  
+
+THE USER CANNOT USE, EXPLOIT OR DISTRIBUTE THE *SOFTWARE* FOR COMMERCIAL PURPOSES  
+WITHOUT PRIOR AND EXPLICIT CONSENT OF LICENSORS. YOU MUST CONTACT INRIA FOR ANY  
+UNAUTHORIZED USE: stip-sophia.transfert@inria.fr . ANY SUCH ACTION WILL  
+CONSTITUTE A FORGERY. THIS *SOFTWARE* IS PROVIDED "AS IS" WITHOUT ANY WARRANTIES  
+OF ANY NATURE AND ANY EXPRESS OR IMPLIED WARRANTIES, WITH REGARDS TO COMMERCIAL  
+USE, PROFESSIONNAL USE, LEGAL OR NOT, OR OTHER, OR COMMERCIALISATION OR  
+ADAPTATION. UNLESS EXPLICITLY PROVIDED BY LAW, IN NO EVENT, SHALL INRIA OR THE  
+AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR  
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE  
+GOODS OR SERVICES, LOSS OF USE, DATA, OR PROFITS OR BUSINESS INTERRUPTION)  
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT  
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING FROM, OUT OF OR  
+IN CONNECTION WITH THE *SOFTWARE* OR THE USE OR OTHER DEALINGS IN THE *SOFTWARE*.  

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/README.md
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/README.md
@@ -1,0 +1,27 @@
+# Differentiable X-ray Gaussian Rasterization and Voxelization
+
+Used as the rasterization and voxelization engine for the paper "R$^2$-Gaussian: Rectifying Radiative Gaussian Splatting for Tomographic Reconstruction". The repository is adapted from [diff-gaussian-rasterization](https://github.com/graphdeco-inria/diff-gaussian-rasterization).
+
+## BibTex
+
+```sh
+@misc{zha2024r2gaussian,
+      title={R$^2$-Gaussian: Rectifying Radiative Gaussian Splatting for Tomographic Reconstruction}, 
+      author={Ruyi Zha and Tao Jun Lin and Yuanhao Cai and Jiwen Cao and Yanhao Zhang and Hongdong Li},
+      year={2024},
+      eprint={2405.20693},
+      archivePrefix={arXiv},
+      primaryClass={eess.IV}
+}
+
+@Article{kerbl3Dgaussians,
+      author       = {Kerbl, Bernhard and Kopanas, Georgios and Leimk{\"u}hler, Thomas and Drettakis, George},
+      title        = {3D Gaussian Splatting for Real-Time Radiance Field Rendering},
+      journal      = {ACM Transactions on Graphics},
+      number       = {4},
+      volume       = {42},
+      month        = {July},
+      year         = {2023},
+      url          = {https://repo-sam.inria.fr/fungraph/3d-gaussian-splatting/}
+}
+```

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/auxiliary.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/auxiliary.h
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef CUDA_RASTERIZER_AUXILIARY_H_INCLUDED
+#define CUDA_RASTERIZER_AUXILIARY_H_INCLUDED
+
+#include "config.h"
+#include "stdio.h"
+
+#define BLOCK_SIZE (BLOCK_X * BLOCK_Y)
+#define NUM_WARPS (BLOCK_SIZE/32)
+#define M_PI 3.141592653589793
+#define RENDER_AXUTILITY_GEO_FORWARD 1
+// #define RENDER_AXUTILITY_ETA_FORWARD 0
+// #define RENDER_AXUTILITY_ETAGEO_FORWARD 0
+#define GEO_OFFSET 0
+// #define ETA_OFFSET 1
+// #define ETAGEO_OFFSET 2
+
+// Spherical harmonics coefficients
+__device__ const float SH_C0 = 0.28209479177387814f;
+__device__ const float SH_C1 = 0.4886025119029199f;
+__device__ const float SH_C2[] = {
+	1.0925484305920792f,
+	-1.0925484305920792f,
+	0.31539156525252005f,
+	-1.0925484305920792f,
+	0.5462742152960396f
+};
+__device__ const float SH_C3[] = {
+	-0.5900435899266435f,
+	2.890611442640554f,
+	-0.4570457994644658f,
+	0.3731763325901154f,
+	-0.4570457994644658f,
+	1.445305721320277f,
+	-0.5900435899266435f
+};
+
+__forceinline__ __device__ float ndc2Pix(float v, int S)
+{
+	return ((v + 1.0) * S - 1.0) * 0.5;   // -1.0 is used to compensate for half pixel
+}
+
+__forceinline__ __device__ void getRect(const float2 p, int max_radius, uint2& rect_min, uint2& rect_max, dim3 grid)
+{
+	rect_min = {
+		min(grid.x, max((int)0, (int)((p.x - max_radius) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y - max_radius) / BLOCK_Y)))
+	};
+	rect_max = {
+		min(grid.x, max((int)0, (int)((p.x + max_radius + BLOCK_X - 1) / BLOCK_X))),
+		min(grid.y, max((int)0, (int)((p.y + max_radius + BLOCK_Y - 1) / BLOCK_Y)))
+	};
+}
+
+__forceinline__ __device__ float3 transformPoint4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float4 transformPoint4x4(const float3& p, const float* matrix)
+{
+	float4 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+		matrix[3] * p.x + matrix[7] * p.y + matrix[11] * p.z + matrix[15]
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z,
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z,
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3Transpose(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[1] * p.y + matrix[2] * p.z,
+		matrix[4] * p.x + matrix[5] * p.y + matrix[6] * p.z,
+		matrix[8] * p.x + matrix[9] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float dnormvdz(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+	float dnormvdz = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdz;
+}
+
+__forceinline__ __device__ float3 dnormvdv(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float3 dnormvdv;
+	dnormvdv.x = ((+sum2 - v.x * v.x) * dv.x - v.y * v.x * dv.y - v.z * v.x * dv.z) * invsum32;
+	dnormvdv.y = (-v.x * v.y * dv.x + (sum2 - v.y * v.y) * dv.y - v.z * v.y * dv.z) * invsum32;
+	dnormvdv.z = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float4 dnormvdv(float4 v, float4 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float4 vdv = { v.x * dv.x, v.y * dv.y, v.z * dv.z, v.w * dv.w };
+	float vdv_sum = vdv.x + vdv.y + vdv.z + vdv.w;
+	float4 dnormvdv;
+	dnormvdv.x = ((sum2 - v.x * v.x) * dv.x - v.x * (vdv_sum - vdv.x)) * invsum32;
+	dnormvdv.y = ((sum2 - v.y * v.y) * dv.y - v.y * (vdv_sum - vdv.y)) * invsum32;
+	dnormvdv.z = ((sum2 - v.z * v.z) * dv.z - v.z * (vdv_sum - vdv.z)) * invsum32;
+	dnormvdv.w = ((sum2 - v.w * v.w) * dv.w - v.w * (vdv_sum - vdv.w)) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float sigmoid(float x)
+{
+	return 1.0f / (1.0f + expf(-x));
+}
+
+__forceinline__ __device__ bool in_frustum(int idx,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool prefiltered,
+	float3& p_view)
+{
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// Bring points to screen space
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+	p_view = transformPoint4x3(p_orig, viewmatrix);
+
+	if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	{
+		if (prefiltered)
+		{
+			printf("Point is filtered although prefiltered is set. This shouldn't happen!");
+			__trap();
+		}
+		return false;
+	}
+	return true;
+}
+
+#define CHECK_CUDA(A, debug) \
+A; if(debug) { \
+auto ret = cudaDeviceSynchronize(); \
+if (ret != cudaSuccess) { \
+std::cerr << "\n[CUDA ERROR] in " << __FILE__ << "\nLine " << __LINE__ << ": " << cudaGetErrorString(ret); \
+throw std::runtime_error(cudaGetErrorString(ret)); \
+} \
+}
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/backward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/backward.cu
@@ -1,0 +1,511 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "backward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Backward version of INVERSE 2D covariance matrix computation
+// (due to length launched as separate kernel before other 
+// backward steps contained in preprocess)
+__global__ void computeCov2DCUDA(int P,
+	const float3* means,
+	const int* radii,
+	const float* cov3Ds,
+	const float h_x, float h_y,
+	const float tan_fovx, float tan_fovy,
+	const float* view_matrix,
+	const float* dL_dconics,
+	const float* dL_detas,
+	float3* dL_dmeans,
+	float* dL_dcov,
+	const int mode)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	// Reading location of 3D covariance for this Gaussian
+	const float* cov3D = cov3Ds + 6 * idx;
+
+	// Fetch gradients, recompute 2D covariance and relevant 
+	// intermediate forward results needed in the backward.
+	float3 mean = means[idx];
+	float3 dL_dconic = { dL_dconics[4 * idx], dL_dconics[4 * idx + 1], dL_dconics[4 * idx + 3] };
+	float dL_deta = dL_detas[idx]; 
+	float3 t = transformPoint4x3(mean, view_matrix);
+
+	glm::mat3 J;
+	float x_grad_mul, y_grad_mul;
+	if (mode == 0){  // parallel mode
+		const float limx = 1.3f;
+		const float limy = 1.3f;
+		t.x = min(limx, max(-limx, t.x));
+		t.y = min(limx, max(-limx, t.y));
+		
+		x_grad_mul = t.x < -limx || t.x > limx ? 0 : 1;
+		y_grad_mul = t.y < -limy || t.y > limy ? 0 : 1;
+
+		J = glm::mat3(
+		h_x, 0.0f, 0.0f,
+		0.0f, h_y, 0.0f,
+		0, 0, 1.0f);
+	}
+	else  // cone beam
+	{
+		const float limx = 1.3f * tan_fovx;
+		const float limy = 1.3f * tan_fovy;
+		const float txtz = t.x / t.z;
+		const float tytz = t.y / t.z;
+		t.x = min(limx, max(-limx, txtz)) * t.z;
+		t.y = min(limy, max(-limy, tytz)) * t.z;
+		
+		x_grad_mul = txtz < -limx || txtz > limx ? 0 : 1;
+		y_grad_mul = tytz < -limy || tytz > limy ? 0 : 1;
+
+		const float l = sqrt(t.x * t.x +  t.y * t.y + t.z * t.z);
+		J = glm::mat3(
+			h_x / t.z, 0.0f, -(h_x * t.x) / (t.z * t.z),
+			0.0f, h_y / t.z, -(h_y * t.y) / (t.z * t.z),
+			t.x / l, t.y / l, t.z / l);
+	}
+
+	glm::mat3 W = glm::mat3(
+		view_matrix[0], view_matrix[4], view_matrix[8],
+		view_matrix[1], view_matrix[5], view_matrix[9],
+		view_matrix[2], view_matrix[6], view_matrix[10]);
+
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+
+	glm::mat3 M = W * J;
+
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+
+	// Use helper variables for 2D covariance entries. More compact.
+	float hata = cov[0][0] += 0.0f;
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1] += 0.0f;
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+
+	float dL_dhata = 0, dL_dhatb = 0, dL_dhatc = 0, dL_dhatd = 0, dL_dhate = 0, dL_dhatf = 0;
+	float denom = hata * hatd - hatb * hatb;
+	float denom2inv = 1.0f / ((denom * denom) + 0.0000001f);
+	float diamond = hata * hatd - hatb * hatb;
+
+	// eta part gradient
+	float circ = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	float eta_square = 2 * M_PI * circ / diamond;
+	float eta = 0.0f;
+	if (eta_square > 0.0f){
+		eta = sqrt(2 * M_PI * circ / diamond);
+	}
+	float pi_eta= M_PI / (eta + 0.0000001f);
+	float circ_diamond = circ / diamond;
+
+	if (denom2inv != 0.0f && eta != 0.0f)
+	{
+		// exp(*) part gradient
+		dL_dhata = denom2inv * (-hatd * hatd * dL_dconic.x + hatb * hatd * dL_dconic.y + (denom - hata * hatd) * dL_dconic.z);  // We remove 2 here because in render we do not *0.5
+		dL_dhatd = denom2inv * (-hata * hata * dL_dconic.z + hata * hatb * dL_dconic.y + (denom - hata * hatd) * dL_dconic.x);  // We remove 2 here because in render we do not *0.5
+		dL_dhatb = denom2inv * (2 * hatb * hatd * dL_dconic.x - (denom + 2 * hatb * hatb) * dL_dconic.y + 2 * hata * hatb * dL_dconic.z);
+
+		dL_dhata += pi_eta * ((hatd * hatf - hate * hate) / diamond -  hatd * circ_diamond / diamond) * dL_deta;
+		dL_dhatb += pi_eta * ((2 * hatc * hate - 2 * hatf * hatb) / diamond + 2 * hatb * circ_diamond / diamond) * dL_deta;
+		dL_dhatc += pi_eta * ((2 * hatb * hate - 2 * hatd * hatc) / diamond) * dL_deta;
+		dL_dhatd += pi_eta * ((hata * hatf - hatc * hatc) / diamond -  hata *circ_diamond / diamond) * dL_deta;
+		dL_dhate += pi_eta * ((2 * hatb * hatc - 2 * hata * hate) / diamond) * dL_deta;
+		dL_dhatf += pi_eta * ((hata * hatd - hatb * hatb) / diamond) * dL_deta;
+
+		// Gradients of loss L w.r.t. each 3D covariance matrix (Vrk) entry
+		// dL_da
+		dL_dcov[6 * idx + 0] += M[0][0]*M[0][0]*dL_dhata + M[0][0]*M[1][0]*dL_dhatb + M[0][0]*M[2][0]*dL_dhatc + M[1][0]*M[1][0]*dL_dhatd + M[1][0]*M[2][0]*dL_dhate + M[2][0]*M[2][0]*dL_dhatf;
+		// dL_dd
+		dL_dcov[6 * idx + 3] += M[0][1]*M[0][1]*dL_dhata + M[0][1]*M[1][1]*dL_dhatb + M[0][1]*M[2][1]*dL_dhatc + M[1][1]*M[1][1]*dL_dhatd + M[1][1]*M[2][1]*dL_dhate + M[2][1]*M[2][1]*dL_dhatf;
+		// dL_df
+		dL_dcov[6 * idx + 5] += M[0][2]*M[0][2]*dL_dhata + M[0][2]*M[1][2]*dL_dhatb + M[0][2]*M[2][2]*dL_dhatc + M[1][2]*M[1][2]*dL_dhatd + M[1][2]*M[2][2]*dL_dhate + M[2][2]*M[2][2]*dL_dhatf;
+		
+		// dL_db
+		dL_dcov[6 * idx + 1] += 2*M[0][0]*M[0][1]*dL_dhata + (M[0][1]*M[1][0]+M[0][0]*M[1][1])*dL_dhatb + (M[0][1]*M[2][0]+M[0][0]*M[2][1])*dL_dhatc + 2*M[1][0]*M[1][1]*dL_dhatd + (M[1][1]*M[2][0]+M[1][0]*M[2][1])*dL_dhate + 2*M[2][0]*M[2][1]*dL_dhatf;
+		// dL_dc
+		dL_dcov[6 * idx + 2] += 2*M[0][0]*M[0][2]*dL_dhata + (M[0][2]*M[1][0]+M[0][0]*M[1][2])*dL_dhatb + (M[0][2]*M[2][0]+M[0][0]*M[2][2])*dL_dhatc + 2*M[1][0]*M[1][2]*dL_dhatd + (M[1][2]*M[2][0]+M[1][0]*M[2][2])*dL_dhate + 2*M[2][0]*M[2][2]*dL_dhatf;
+		// dL_de
+		dL_dcov[6 * idx + 4] += 2*M[0][1]*M[0][2]*dL_dhata + (M[0][2]*M[1][1]+M[0][1]*M[1][2])*dL_dhatb + (M[0][2]*M[2][1]+M[0][1]*M[2][2])*dL_dhatc + 2*M[1][1]*M[1][2]*dL_dhatd + (M[1][2]*M[2][1]+M[1][1]*M[2][2])*dL_dhate + 2*M[2][1]*M[2][2]*dL_dhatf;
+	}
+	else
+	{
+		for (int i = 0; i < 6; i++)
+			dL_dcov[6 * idx + i] = 0;
+	}
+
+	if (mode == 1){
+		// Gradients of loss w.r.t. M
+		// cov2D = transpose(M) * transpose(Vrk) * M;
+
+		float a = cov3D[0];
+		float b = cov3D[1];
+		float c = cov3D[2];
+		float d = cov3D[3];
+		float e = cov3D[4];
+		float f = cov3D[5];
+
+		float dL_dM00 = 2*(M[0][0]*a+M[0][1]*b + M[0][2]*c)*dL_dhata + (M[1][0]*a+M[1][1]*b+M[1][2]*c)*dL_dhatb + (M[2][0]*a+M[2][1]*b+M[2][2]*c)*dL_dhatc;
+		float dL_dM01 = 2*(M[0][0]*b+M[0][1]*d + M[0][2]*e)*dL_dhata + (M[1][0]*b+M[1][1]*d+M[1][2]*e)*dL_dhatb + (M[2][0]*b+M[2][1]*d+M[2][2]*e)*dL_dhatc;
+		float dL_dM02 = 2*(M[0][0]*c+M[0][1]*e + M[0][2]*f)*dL_dhata + (M[1][0]*c+M[1][1]*e+M[1][2]*f)*dL_dhatb + (M[2][0]*c+M[2][1]*e+M[2][2]*f)*dL_dhatc;
+
+		float dL_dM10 = (M[0][0]*a+M[0][1]*b+M[0][2]*c)*dL_dhatb + 2*(M[1][0]*a+M[1][1]*b+M[1][2]*c)*dL_dhatd + (M[2][0]*a+M[2][1]*b+M[2][2]*c)*dL_dhate;
+		float dL_dM11 = (M[0][0]*b+M[0][1]*d+M[0][2]*e)*dL_dhatb + 2*(M[1][0]*b+M[1][1]*d+M[1][2]*e)*dL_dhatd + (M[2][0]*b+M[2][1]*d+M[2][2]*e)*dL_dhate;
+		float dL_dM12 = (M[0][0]*c+M[0][1]*e+M[0][2]*f)*dL_dhatb + 2*(M[1][0]*c+M[1][1]*e+M[1][2]*f)*dL_dhatd + (M[2][0]*c+M[2][1]*e+M[2][2]*f)*dL_dhate;
+
+		float dL_dM20 = (M[0][0]*a+M[0][1]*b+M[0][2]*c)*dL_dhatc + (M[1][0]*a+M[1][1]*b+M[1][2]*c)*dL_dhate + 2*(M[2][0]*a+M[2][1]*b+M[2][2]*c)*dL_dhatf;
+		float dL_dM21 = (M[0][0]*b+M[0][1]*d+M[0][2]*e)*dL_dhatc + (M[1][0]*b+M[1][1]*d+M[1][2]*e)*dL_dhate + 2*(M[2][0]*b+M[2][1]*d+M[2][2]*e)*dL_dhatf;
+		float dL_dM22 = (M[0][0]*c+M[0][1]*e+M[0][2]*f)*dL_dhatc + (M[1][0]*c+M[1][1]*e+M[1][2]*f)*dL_dhate + 2*(M[2][0]*c+M[2][1]*e+M[2][2]*f)*dL_dhatf;
+
+		float dL_dJ00 = W[0][0]*dL_dM00 + W[0][1]*dL_dM01 + W[0][2]*dL_dM02;
+		float dL_dJ02 = W[2][0]*dL_dM00 + W[2][1]*dL_dM01 + W[2][2]*dL_dM02;
+		float dL_dJ11 = W[1][0]*dL_dM10 + W[1][1]*dL_dM11 + W[1][2]*dL_dM12;
+		float dL_dJ12 = W[2][0]*dL_dM10 + W[2][1]*dL_dM11 + W[2][2]*dL_dM12;
+		float dL_dJ20 = W[0][0]*dL_dM20 + W[0][1]*dL_dM21 + W[0][2]*dL_dM22;
+		float dL_dJ21 = W[1][0]*dL_dM20 + W[1][1]*dL_dM21 + W[1][2]*dL_dM22;
+		float dL_dJ22 = W[2][0]*dL_dM20 + W[2][1]*dL_dM21 + W[2][2]*dL_dM22;
+
+		float tx = t.x;
+		float ty = t.y;
+		float tz = t.z;
+		float inv_tz = 1.f / tz;
+		float inv_tz2 = inv_tz * inv_tz;
+		float inv_tz3 = inv_tz2 * inv_tz;
+		float circledcirc = sqrt(tx * tx + ty * ty + tz * tz);
+		float inv_circledcirc3 = 1 / (circledcirc * circledcirc * circledcirc);
+		float dL_dtx = x_grad_mul * (-h_x*inv_tz2*dL_dJ02 + (1/circledcirc - tx*tx*inv_circledcirc3)*dL_dJ20 - tx*ty*inv_circledcirc3*dL_dJ21 - tx*tz*inv_circledcirc3*dL_dJ22);
+		float dL_dty = y_grad_mul * (-h_y*inv_tz2*dL_dJ12 - tx*ty*inv_circledcirc3*dL_dJ20 + (1/circledcirc - ty*ty*inv_circledcirc3)*dL_dJ21 - ty*tz*inv_circledcirc3*dL_dJ22);
+		float dL_dtz = -h_x*inv_tz2*dL_dJ00 + 2*h_x*tx*inv_tz3*dL_dJ02 - h_y*inv_tz2*dL_dJ11 + 2*h_y*ty*inv_tz3*dL_dJ12 - tx*tz*inv_circledcirc3*dL_dJ20 - ty*tz*inv_circledcirc3*dL_dJ21 + (1/circledcirc-tz*tz*inv_circledcirc3)*dL_dJ22;
+
+		float3 dL_dmean = transformVec4x3Transpose({ dL_dtx, dL_dty, dL_dtz }, view_matrix);
+
+		// Gradients of loss w.r.t. Gaussian means, but only the portion 
+		// that is caused because the mean affects the covariance matrix.
+		// Additional mean gradient is accumulated in BACKWARD::preprocess.
+		dL_dmeans[idx] = dL_dmean;
+
+	}
+}
+
+// Backward pass for the conversion of scale and rotation to a 
+// 3D covariance matrix for each Gaussian. 
+__device__ void computeCov3D(int idx, const glm::vec3 scale, float mod, const glm::vec4 rot, const float* dL_dcov3Ds, glm::vec3* dL_dscales, glm::vec4* dL_drots)
+{
+	// Recompute (intermediate) results for the 3D covariance computation.
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 S = glm::mat3(1.0f);
+
+	glm::vec3 s = mod * scale;
+	S[0][0] = s.x;
+	S[1][1] = s.y;
+	S[2][2] = s.z;
+
+	glm::mat3 M = S * R;
+
+	const float* dL_dcov3D = dL_dcov3Ds + 6 * idx;
+
+	glm::vec3 dunc(dL_dcov3D[0], dL_dcov3D[3], dL_dcov3D[5]);
+	glm::vec3 ounc = 0.5f * glm::vec3(dL_dcov3D[1], dL_dcov3D[2], dL_dcov3D[4]);
+
+	// Convert per-element covariance loss gradients to matrix form
+	glm::mat3 dL_dSigma = glm::mat3(
+		dL_dcov3D[0], 0.5f * dL_dcov3D[1], 0.5f * dL_dcov3D[2],
+		0.5f * dL_dcov3D[1], dL_dcov3D[3], 0.5f * dL_dcov3D[4],
+		0.5f * dL_dcov3D[2], 0.5f * dL_dcov3D[4], dL_dcov3D[5]
+	);
+
+	// Compute loss gradient w.r.t. matrix M
+	// dSigma_dM = 2 * M
+	glm::mat3 dL_dM = 2.0f * M * dL_dSigma;
+
+	glm::mat3 Rt = glm::transpose(R);
+	glm::mat3 dL_dMt = glm::transpose(dL_dM);
+
+	// Gradients of loss w.r.t. scale
+	glm::vec3* dL_dscale = dL_dscales + idx;
+	dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
+	dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
+	dL_dscale->z = glm::dot(Rt[2], dL_dMt[2]);
+
+	dL_dMt[0] *= s.x;
+	dL_dMt[1] *= s.y;
+	dL_dMt[2] *= s.z;
+
+	// Gradients of loss w.r.t. normalized quaternion
+	glm::vec4 dL_dq;
+	dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2] - dL_dMt[2][1]);
+	dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2] - dL_dMt[2][1]) - 4 * x * (dL_dMt[2][2] + dL_dMt[1][1]);
+	dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * y * (dL_dMt[2][2] + dL_dMt[0][0]);
+	dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
+
+	// Gradients of loss w.r.t. unnormalized quaternion
+	float4* dL_drot = (float4*)(dL_drots + idx);
+	*dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w };//dnormvdv(float4{ rot.x, rot.y, rot.z, rot.w }, float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w });
+}
+
+// Backward pass of the preprocessing steps, except
+// for the covariance computation and inversion
+// (those are handled by a previous kernel call)
+template<int C>
+__global__ void preprocessCUDA(
+	int P,
+	const float3* means,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* proj,
+	const glm::vec3* campos,
+	const float3* dL_dmean2D,
+	glm::vec3* dL_dmeans,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	float3 m = means[idx];
+
+	// Taking care of gradients from the screenspace points
+	float4 m_hom = transformPoint4x4(m, proj);
+	float m_w = 1.0f / (m_hom.w + 0.0000001f);
+
+	// Compute loss gradient w.r.t. 3D means due to gradients of 2D means
+	// from rendering procedure
+	glm::vec3 dL_dmean;
+	float mul1 = (proj[0] * m.x + proj[4] * m.y + proj[8] * m.z + proj[12]) * m_w * m_w;
+	float mul2 = (proj[1] * m.x + proj[5] * m.y + proj[9] * m.z + proj[13]) * m_w * m_w;
+	dL_dmean.x = (proj[0] * m_w - proj[3] * mul1) * dL_dmean2D[idx].x + (proj[1] * m_w - proj[3] * mul2) * dL_dmean2D[idx].y;
+	dL_dmean.y = (proj[4] * m_w - proj[7] * mul1) * dL_dmean2D[idx].x + (proj[5] * m_w - proj[7] * mul2) * dL_dmean2D[idx].y;
+	dL_dmean.z = (proj[8] * m_w - proj[11] * mul1) * dL_dmean2D[idx].x + (proj[9] * m_w - proj[11] * mul2) * dL_dmean2D[idx].y;
+
+	// That's the second part of the mean gradient. Previous computation
+	// of cov2D and following SH conversion also affects it.
+	dL_dmeans[idx] += dL_dmean;
+
+	// Compute gradient updates due to computing covariance from scale/rotation
+	if (scales)
+		computeCov3D(idx, scales[idx], scale_modifier, rotations[idx], dL_dcov3D, dL_dscale, dL_drot);
+}
+
+// Backward pass for order-independent per-Gaussian accumulation. Each block
+// owns one Gaussian, so its pixel contributions can be reduced locally.
+template <uint32_t C>
+__global__ void __launch_bounds__(BLOCK_SIZE)
+renderUnsortedCUDA(
+	int P,
+	dim3 tile_grid,
+	int W, int H,
+	const int* __restrict__ radii,
+	const float2* __restrict__ points_xy_image,
+	const float4* __restrict__ conic_opacity,
+	const float* __restrict__ etas,
+	const float* __restrict__ dL_dpixels,
+	float3* __restrict__ dL_dmean2D,
+	float4* __restrict__ dL_dconic2D,
+	float* __restrict__ dL_dopacity,
+	float* __restrict__ dL_deta)
+{
+	const int idx = blockIdx.x;
+	if (idx >= P || radii[idx] <= 0)
+		return;
+
+	__shared__ float gradient[8];
+	if (threadIdx.x < 8)
+		gradient[threadIdx.x] = 0.0f;
+	__syncthreads();
+
+	const float2 xy = points_xy_image[idx];
+	const float4 con_o = conic_opacity[idx];
+	const float eta = etas[idx];
+	uint2 rect_min, rect_max;
+	getRect(xy, radii[idx], rect_min, rect_max, tile_grid);
+	const int min_x = rect_min.x * BLOCK_X;
+	const int min_y = rect_min.y * BLOCK_Y;
+	const int max_x = min((int)rect_max.x * BLOCK_X, W);
+	const int max_y = min((int)rect_max.y * BLOCK_Y, H);
+	const int rect_w = max_x - min_x;
+	const int pixel_count = rect_w * (max_y - min_y);
+	const float ddelx_dx = 0.5f * W;
+	const float ddely_dy = 0.5f * H;
+
+	float local[8] = { 0.0f };
+	for (int linear = threadIdx.x; linear < pixel_count; linear += blockDim.x)
+	{
+		const int px = min_x + linear % rect_w;
+		const int py = min_y + linear / rect_w;
+		const int pix_id = py * W + px;
+		const float2 d = { xy.x - (float)px, xy.y - (float)py };
+		const float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+		if (power > 0.0f)
+			continue;
+
+		const float G = exp(power);
+		const float alpha = con_o.w * eta * G;
+		if (alpha < 0.00001f)
+			continue;
+
+		float dL_dalpha = 0.0f;
+		for (int ch = 0; ch < C; ch++)
+			dL_dalpha += dL_dpixels[ch * H * W + pix_id];
+		const float dL_dG = con_o.w * eta * dL_dalpha;
+		const float gdx = G * d.x;
+		const float gdy = G * d.y;
+		const float dG_ddelx = -gdx * con_o.x - gdy * con_o.y;
+		const float dG_ddely = -gdy * con_o.z - gdx * con_o.y;
+		const float dL_dx = dL_dG * dG_ddelx * ddelx_dx;
+		const float dL_dy = dL_dG * dG_ddely * ddely_dy;
+
+		local[0] += dL_dx;
+		local[1] += dL_dy;
+		local[2] += abs(dL_dx) + abs(dL_dy);
+		local[3] += -0.5f * gdx * d.x * dL_dG;
+		local[4] += -1.0f * gdx * d.y * dL_dG;
+		local[5] += -0.5f * gdy * d.y * dL_dG;
+		local[6] += eta * G * dL_dalpha;
+		local[7] += con_o.w * G * dL_dalpha;
+	}
+
+	auto block = cg::this_thread_block();
+	auto warp = cg::tiled_partition<32>(block);
+	for (int i = 0; i < 8; i++)
+	{
+		const float warp_sum = cg::reduce(warp, local[i], cg::plus<float>());
+		if (warp.thread_rank() == 0)
+			atomicAdd(&gradient[i], warp_sum);
+	}
+	__syncthreads();
+	if (threadIdx.x == 0)
+	{
+		dL_dmean2D[idx] = { gradient[0], gradient[1], gradient[2] };
+		dL_dconic2D[idx].x = gradient[3];
+		dL_dconic2D[idx].y = gradient[4];
+		dL_dconic2D[idx].w = gradient[5];
+		dL_dopacity[idx] = gradient[6];
+		dL_deta[idx] = gradient[7];
+	}
+}
+
+
+void BACKWARD::preprocess(
+	int P,
+	const float3* means3D,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* cov3Ds,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float focal_x, float focal_y,
+	const float tan_fovx, float tan_fovy,
+	const glm::vec3* campos,
+	const float3* dL_dmean2D,
+	const float* dL_dconic,
+	const float* dL_deta,
+	glm::vec3* dL_dmean3D,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot,
+	const int mode)
+{
+	// Propagate gradients for the path of 2D conic matrix computation. 
+	// Somewhat long, thus it is its own kernel rather than being part of 
+	// "preprocess". When done, loss gradient w.r.t. 3D means has been
+	// modified and gradient w.r.t. 3D covariance matrix has been computed.	
+	computeCov2DCUDA << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		radii,
+		cov3Ds,
+		focal_x,
+		focal_y,
+		tan_fovx,
+		tan_fovy,
+		viewmatrix,
+		dL_dconic,
+		dL_deta,
+		(float3*)dL_dmean3D,
+		dL_dcov3D,
+		mode);
+
+	// Propagate gradients for remaining steps: finish 3D mean gradients,
+	// propagate color gradients to SH (if desireD), propagate 3D covariance
+	// matrix gradients to scale and rotation.
+	preprocessCUDA<NUM_CHANNELS> << < (P + 255) / 256, 256 >> > (
+		P,
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		projmatrix,
+		campos,
+		(float3*)dL_dmean2D,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		dL_dscale,
+		dL_drot);
+}
+
+void BACKWARD::render(
+	int P,
+	const dim3 tile_grid,
+	int W, int H,
+	const int* radii,
+	const float2* means2D,
+	const float4* conic_opacity,
+	const float* etas,
+	const float* dL_dpixels,
+	float3* dL_dmean2D,
+	float4* dL_dconic2D,
+	float* dL_dopacity,
+	float* dL_deta
+	)
+{
+	renderUnsortedCUDA<NUM_CHANNELS> << <P, BLOCK_SIZE >> >(
+		P,
+		tile_grid,
+		W, H,
+		radii,
+		means2D,
+		conic_opacity,
+		etas,
+		dL_dpixels,
+		dL_dmean2D,
+		dL_dconic2D,
+		dL_dopacity,
+		dL_deta
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/backward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/backward.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_BACKWARD_H_INCLUDED
+#define CUDA_RASTERIZER_BACKWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace BACKWARD
+{
+	void render(
+		int P,
+		const dim3 tile_grid,
+		int W, int H,
+		const int* radii,
+		const float2* means2D,
+		const float4* conic_opacity,
+		const float* etas,
+		const float* dL_dpixels,
+		float3* dL_dmean2D,
+		float4* dL_dconic2D,
+		float* dL_dopacity,
+		float* dL_deta);
+
+	void preprocess(
+		int P,
+		const float3* means,
+		const int* radii,
+		const glm::vec3* scales,
+		const glm::vec4* rotations,
+		const float scale_modifier,
+		const float* cov3Ds,
+		const float* view,
+		const float* proj,
+		const float focal_x, float focal_y,
+		const float tan_fovx, float tan_fovy,
+		const glm::vec3* campos,
+		const float3* dL_dmean2D,
+		const float* dL_dconics,
+		const float* dL_deta,
+		glm::vec3* dL_dmeans,
+		float* dL_dcov3D,
+		glm::vec3* dL_dscale,
+		glm::vec4* dL_drot,
+		const int mode);
+}
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/config.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/config.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_CONFIG_H_INCLUDED
+#define CUDA_RASTERIZER_CONFIG_H_INCLUDED
+
+#define NUM_CHANNELS 1
+#define NUM_OTHERS 1
+#define BLOCK_X 16
+#define BLOCK_Y 16
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/forward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/forward.cu
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+#include <stdio.h> // for debug
+#include "forward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Forward version of 2D covariance matrix computation
+// Section 6.2 EWA Volume Resampling Filter
+__device__ float4 computeCov2D(const float3& mean, float focal_x, float focal_y, float tan_fovx, float tan_fovy, const float* cov3D, const float* viewmatrix, const int mode)
+{
+	// The following models the steps outlined by equations 29
+	// and 31 in "EWA Splatting" (Zwicker et al., 2002). 
+	// Additionally considers aspect / scaling of viewport.
+	// Transposes used to account for row-/column-major conventions.
+
+	// This is the transformation from Source (world) to view (camera)
+	float3 t = transformPoint4x3(mean, viewmatrix);
+    glm::mat3 J;
+	if (mode == 0){  // parallel beam
+		const float limx = 1.3f;
+		const float limy = 1.3f;
+		t.x = min(limx, max(-limx, t.x));
+		t.y = min(limx, max(-limx, t.y));
+
+		// J is eye
+		J = glm::mat3(
+		focal_x, 0.0f, 0.0f,
+		0.0f, focal_y, 0.0f,
+		0.0f, 0.0f, 1.0f);
+	}
+	else  // cone beam
+	{	
+		const float limx = 1.3f * tan_fovx;
+		const float limy = 1.3f * tan_fovy;
+		const float txtz = t.x / t.z;
+		const float tytz = t.y / t.z;
+		// t = Phi^-1(x), eq(26)
+		t.x = min(limx, max(-limx, txtz)) * t.z;
+		t.y = min(limy, max(-limy, tytz)) * t.z;
+		// Jacobian of Affine approximation of projection transformation
+		// eq(29)
+		const float l = sqrt(t.x * t.x +  t.y * t.y + t.z * t.z);
+		J = glm::mat3(
+			focal_x / t.z, 0.0f, -(focal_x * t.x) / (t.z * t.z),
+			0.0f, focal_y / t.z, -(focal_y * t.y) / (t.z * t.z),
+			t.x / l, t.y / l, t.z / l);
+	}
+	
+	// Viewing transformation
+	glm::mat3 W = glm::mat3(
+		viewmatrix[0], viewmatrix[4], viewmatrix[8],
+		viewmatrix[1], viewmatrix[5], viewmatrix[9],
+		viewmatrix[2], viewmatrix[6], viewmatrix[10]);
+	
+	glm::mat3 M = W * J;
+    
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+    
+	// J W Sigma W^M J^M
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+
+	// Apply low-pass filter: every Gaussian should be at least
+	// one pixel wide/high. Discard 3rd row and column.
+	// why 0.3f? 
+	cov[0][0] += 0.0f;
+	cov[1][1] += 0.0f;
+
+	// Compute eta
+	float hata = cov[0][0];
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1];
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+	float diamond = hata * hatd - hatb * hatb;
+	float circ = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	float eta_square = 2 * M_PI * circ / diamond;
+	float eta = 0.0f;
+	if (eta_square > 0.0f){
+		eta = sqrt(2 * M_PI * circ / diamond);
+	}
+
+	// printf("eta: %f\n", eta);
+	// printf("circ: %f\n", circ);
+	// printf("diamond: %f\n", diamond);
+
+	// printf("cov:\n");
+	// printf("%f\t%f\t%f\n", cov[0][0], cov[0][1], cov[0][2]);
+	// printf("%f\t%f\t%f\n", cov[1][0], cov[1][1], cov[1][2]);
+	// printf("%f\t%f\t%f\n", cov[2][0], cov[2][1], cov[2][2]);
+
+
+	return { float(cov[0][0]), float(cov[0][1]), float(cov[1][1]), float(eta) };
+}
+
+// Forward method for converting scale and rotation properties of each
+// Gaussian to a 3D covariance matrix in world space. Also takes care
+// of quaternion normalization.
+__device__ void computeCov3D(const glm::vec3 scale, float mod, const glm::vec4 rot, float* cov3D)
+{
+	// Create scaling matrix
+	glm::mat3 S = glm::mat3(1.0f);
+	S[0][0] = mod * scale.x;
+	S[1][1] = mod * scale.y;
+	S[2][2] = mod * scale.z;
+
+	// Normalize quaternion to get valid rotation
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	// Compute rotation matrix from quaternion
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 M = S * R;
+
+	// Compute 3D world covariance matrix Sigma
+	glm::mat3 Sigma = glm::transpose(M) * M;
+
+	// Covariance is symmetric, only store upper right
+	cov3D[0] = Sigma[0][0];  // a
+	cov3D[1] = Sigma[0][1];  // b
+	cov3D[2] = Sigma[0][2];  // c
+	cov3D[3] = Sigma[1][1];  // d
+	cov3D[4] = Sigma[1][2];  // e
+	cov3D[5] = Sigma[2][2];  // f
+}
+
+// Perform initial steps for each Gaussian prior to rasterization.
+template<int C>
+__global__ void preprocessCUDA(int P,
+	const float* orig_points,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const glm::vec3* cam_pos,
+	const int W, int H,
+	const float tan_fovx, float tan_fovy,
+	const float focal_x, float focal_y,
+	int* radii,
+	float2* points_xy_image,
+	float* cov3Ds,
+	float4* conic_opacity,
+	float* etas,
+	const dim3 grid,
+	bool prefiltered,
+	const int mode
+	)
+{
+	auto idx = cg::this_grid().thread_rank(); //idx
+	if (idx >= P)
+		return;
+
+	// Initialize radius to 0. If this isn't changed, this Gaussian will not
+	// be processed further.
+	radii[idx] = 0;
+
+	// Perform near culling, quit if outside.
+	float3 p_view;
+	if (!in_frustum(idx, orig_points, viewmatrix, projmatrix, prefiltered, p_view)) // 在cuda_rasterizer/auxilliary.cu，顺便计算了p_view：在相机坐标系下的点的3D位置
+		return;
+
+	// Transform point by projecting
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+
+	// If 3D covariance matrix is precomputed, use it, otherwise compute
+	// from scaling and rotation parameters. 
+	const float* cov3D;
+	if (cov3D_precomp != nullptr)
+	{
+		cov3D = cov3D_precomp + idx * 6;
+	}
+	else
+	{
+		computeCov3D(scales[idx], scale_modifier, rotations[idx], cov3Ds + idx * 6);
+		cov3D = cov3Ds + idx * 6;
+	}
+
+	// Compute 2D screen-space covariance matrix
+	float4 cov = computeCov2D(p_orig, focal_x, focal_y, tan_fovx, tan_fovy, cov3D, viewmatrix, mode);
+
+	// Invert covariance (EWA algorithm)
+	float det = (cov.x * cov.z - cov.y * cov.y);
+	if (det == 0.0f)
+		return;
+	float det_inv = 1.f / det;
+	float3 conic = { cov.z * det_inv, -cov.y * det_inv, cov.x * det_inv };
+
+	// Compute extent in screen space (by finding eigenvalues of
+	// 2D covariance matrix). Use extent to compute a bounding rectangle
+	// of screen-space tiles that this Gaussian overlaps with. Quit if
+	// rectangle covers 0 tiles. 
+	float mid = 0.5f * (cov.x + cov.z);
+	float lambda1 = mid + sqrt(max(0.1f, mid * mid - det)); 
+	float lambda2 = mid - sqrt(max(0.1f, mid * mid - det));
+	float my_radius = ceil(3.f * sqrt(max(lambda1, lambda2)));
+	float2 point_image = { ndc2Pix(p_proj.x, W), ndc2Pix(p_proj.y, H) };
+	uint2 rect_min, rect_max;
+	getRect(point_image, my_radius, rect_min, rect_max, grid);
+	if ((rect_max.x - rect_min.x) * (rect_max.y - rect_min.y) == 0)
+		return;
+
+	// Store some useful helper data for the next steps.
+	radii[idx] = my_radius;
+	points_xy_image[idx] = point_image;
+	// Inverse 2D covariance and opacity neatly pack into one float4
+	conic_opacity[idx] = { conic.x, conic.y, conic.z, opacities[idx] };
+	etas[idx] = cov.w;
+}
+
+// X-ray projection is a plain sum of per-Gaussian line integrals. Launch one
+// block per Gaussian and atomically accumulate into the pixels it overlaps;
+// unlike alpha compositing, this operation has no depth-order dependency.
+template <uint32_t CHANNELS>
+__global__ void __launch_bounds__(BLOCK_SIZE)
+renderUnsortedCUDA(
+	int P,
+	dim3 tile_grid,
+	int W, int H,
+	const int* __restrict__ radii,
+	const float2* __restrict__ points_xy_image,
+	const float4* __restrict__ conic_opacity,
+	const float* __restrict__ etas,
+	float* __restrict__ out_color,
+	float* __restrict__ out_others)
+{
+	const int idx = blockIdx.x;
+	if (idx >= P || radii[idx] <= 0)
+		return;
+
+	const float2 xy = points_xy_image[idx];
+	const float4 con_o = conic_opacity[idx];
+	const float eta = etas[idx];
+	uint2 rect_min, rect_max;
+	getRect(xy, radii[idx], rect_min, rect_max, tile_grid);
+
+	const int min_x = rect_min.x * BLOCK_X;
+	const int min_y = rect_min.y * BLOCK_Y;
+	const int max_x = min((int)rect_max.x * BLOCK_X, W);
+	const int max_y = min((int)rect_max.y * BLOCK_Y, H);
+	const int rect_w = max_x - min_x;
+	const int pixel_count = rect_w * (max_y - min_y);
+
+	for (int linear = threadIdx.x; linear < pixel_count; linear += blockDim.x)
+	{
+		const int px = min_x + linear % rect_w;
+		const int py = min_y + linear / rect_w;
+		const int pix_id = py * W + px;
+		const float2 d = { xy.x - (float)px, xy.y - (float)py };
+		const float power = -0.5f * (con_o.x * d.x * d.x + con_o.z * d.y * d.y) - con_o.y * d.x * d.y;
+		if (power > 0.0f)
+			continue;
+
+		const float G = exp(power);
+		#if RENDER_AXUTILITY_GEO_FORWARD
+			atomicAdd(&out_others[GEO_OFFSET * H * W + pix_id], G);
+		#endif
+
+		const float alpha = con_o.w * eta * G;
+		if (alpha < 0.00001f)
+			continue;
+		for (int ch = 0; ch < CHANNELS; ch++)
+			atomicAdd(&out_color[ch * H * W + pix_id], alpha);
+	}
+}
+
+
+void FORWARD::render(
+	int P,
+	const dim3 tile_grid,
+	int W, int H,
+	const int* radii,
+	const float2* means2D,
+	const float4* conic_opacity,
+	const float* etas,
+	float* out_color,
+	float* out_others)
+{
+	renderUnsortedCUDA<NUM_CHANNELS> << <P, BLOCK_SIZE >> > (
+		P,
+		tile_grid,
+		W, H,
+		radii,
+		means2D,
+		conic_opacity,
+		etas,
+		out_color,
+		out_others);
+}
+
+
+void FORWARD::preprocess(int P,
+	const float* means3D,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const glm::vec3* cam_pos,
+	const int W, int H,
+	const float focal_x, float focal_y,
+	const float tan_fovx, float tan_fovy,
+	int* radii,
+	float2* means2D,
+	float* cov3Ds,
+	float4* conic_opacity,
+	float* etas,
+	const dim3 grid,
+	bool prefiltered,
+	const int mode
+	)
+{
+	preprocessCUDA<NUM_CHANNELS> << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		scales,
+		scale_modifier,
+		rotations,
+		opacities,
+		cov3D_precomp,
+		viewmatrix, 
+		projmatrix,
+		cam_pos,
+		W, H,
+		tan_fovx, tan_fovy,
+		focal_x, focal_y,
+		radii,
+		means2D,
+		cov3Ds,
+		conic_opacity,
+		etas,
+		grid,
+		prefiltered,
+		mode
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/forward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/forward.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef CUDA_RASTERIZER_FORWARD_H_INCLUDED
+#define CUDA_RASTERIZER_FORWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace FORWARD
+{
+	// Perform initial steps for each Gaussian prior to rasterization.
+	void preprocess(int P, 
+		const float* orig_points,
+		const glm::vec3* scales,
+		const float scale_modifier,
+		const glm::vec4* rotations,
+		const float* opacities,
+		const float* cov3D_precomp,
+		const float* viewmatrix,
+		const float* projmatrix,
+		const glm::vec3* cam_pos,
+		const int W, int H,
+		const float focal_x, float focal_y,
+		const float tan_fovx, float tan_fovy,
+		int* radii,
+		float2* points_xy_image,
+		float* cov3Ds,
+		float4* conic_opacity,
+		float* etas,
+		const dim3 grid,
+		bool prefiltered,
+		const int mode
+		);
+
+	// Order-independent X-ray accumulation, one block per Gaussian.
+	void render(
+		int P,
+		const dim3 tile_grid,
+		int W, int H,
+		const int* radii,
+		const float2* points_xy_image,
+		const float4* conic_opacity,
+		const float* etas,
+		float* out_color,
+		float* out_others);
+}
+
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/rasterizer.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/rasterizer.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef CUDA_RASTERIZER_H_INCLUDED
+#define CUDA_RASTERIZER_H_INCLUDED
+
+#include <vector>
+#include <functional>
+
+namespace CudaRasterizer
+{
+    class Rasterizer
+	{
+	public:
+        
+        // Basic Function
+		static void markVisible(
+			int P,
+			float* means3D,
+			float* viewmatrix,
+			float* projmatrix,
+			bool* present);
+		
+		static int forward(
+			std::function<char* (size_t)> geometryBuffer,
+			std::function<char* (size_t)> binningBuffer,
+			std::function<char* (size_t)> imageBuffer,
+			const int P,
+			const int width, int height,
+			const float* means3D,
+			const float* opacities,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const float* viewmatrix,
+			const float* projmatrix,
+			const float* cam_pos,
+			const float tan_fovx, float tan_fovy,
+			const bool prefiltered,
+			const int mode,
+			float* out_color,
+			float* out_others,
+			int* radii = nullptr,
+			bool debug = false);
+
+		static void backward(
+			const int P, int R,
+			const int width, int height,
+			const float* means3D,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const float* viewmatrix,
+			const float* projmatrix,
+			const float* campos,
+			const float tan_fovx, float tan_fovy,
+			const int* radii,
+			char* geom_buffer,
+			char* binning_buffer,
+			char* image_buffer,
+			const float* dL_dpix,
+			float* dL_dmean2D,
+			float* dL_dconic,
+			float* dL_dopacity,
+			float* dL_deta,
+			float* dL_dmean3D,
+			float* dL_dcov3D,
+			float* dL_dscale,
+			float* dL_drot,
+			const int mode,
+			bool debug);
+	};
+
+};
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/rasterizer_impl.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/rasterizer_impl.cu
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "rasterizer_impl.h"
+#include <iostream>
+#include <fstream>
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+#include "auxiliary.h"
+#include "forward.h"
+#include "backward.h"
+
+// Wrapper method to call auxiliary coarse frustum containment test.
+// Mark all Gaussians that pass it.
+__global__ void checkFrustum(int P,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool* present)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	float3 p_view;
+	present[idx] = in_frustum(idx, orig_points, viewmatrix, projmatrix, false, p_view);
+}
+
+// Mark Gaussians as visible/invisible, based on view frustum testing
+void CudaRasterizer::Rasterizer::markVisible(
+	int P,
+	float* means3D,
+	float* viewmatrix,
+	float* projmatrix,
+	bool* present)
+{
+	checkFrustum << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		viewmatrix, projmatrix,
+		present);
+}
+
+CudaRasterizer::GeometryState CudaRasterizer::GeometryState::fromChunk(char*& chunk, size_t P)
+{
+	GeometryState geom;
+	obtain(chunk, geom.internal_radii, P, 128);
+	obtain(chunk, geom.means2D, P, 128);
+	obtain(chunk, geom.cov3D, P * 6, 128);
+	obtain(chunk, geom.conic_opacity, P, 128);
+	obtain(chunk, geom.etas, P, 128);
+	return geom;
+}
+
+// Forward rendering procedure for differentiable rasterization
+// of Gaussians.
+int CudaRasterizer::Rasterizer::forward(
+	std::function<char* (size_t)> geometryBuffer,
+	std::function<char* (size_t)> binningBuffer,
+	std::function<char* (size_t)> imageBuffer,
+	const int P, 
+	const int width, int height,
+	const float* means3D,
+	const float* opacities,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float* cam_pos,
+	const float tan_fovx, float tan_fovy,
+	const bool prefiltered,
+	const int mode,
+	float* out_color,
+	float* out_others,
+	int* radii,
+	bool debug)
+{	
+	(void)binningBuffer;
+	(void)imageBuffer;
+
+	const float focal_y = height / (2.0f * tan_fovy);  // tan_fovy=1 when parallel  focal_y = height * (DSD / proj_phy_h)
+	const float focal_x = width / (2.0f * tan_fovx); // tan_fovx=1 when parallel   focal_x = weight * (DSD / proj_phy_w)
+
+	size_t chunk_size = required<GeometryState>(P);
+	char* chunkptr = geometryBuffer(chunk_size);
+	GeometryState geomState = GeometryState::fromChunk(chunkptr, P);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
+
+    if (NUM_CHANNELS != 1)
+    {
+        throw std::runtime_error("This version of Diff Gaussian Splatting only handle opacity, not RGB");
+    }
+
+	// Run preprocessing per-Gaussian (transformation, bounding, conversion of SHs to RGB)
+	CHECK_CUDA(FORWARD::preprocess(
+		P, 
+		means3D,
+		(glm::vec3*)scales,
+		scale_modifier,
+		(glm::vec4*)rotations,
+		opacities,
+		cov3D_precomp,
+		viewmatrix, projmatrix,
+		(glm::vec3*)cam_pos,
+		width, height,
+		focal_x, focal_y,
+		tan_fovx, tan_fovy,
+		radii,
+		geomState.means2D,
+		geomState.cov3D,
+		geomState.conic_opacity,
+		geomState.etas,
+		tile_grid,
+		prefiltered,
+		mode
+	), debug)
+
+	// Accumulate every Gaussian directly into its covered pixels. X-ray line
+	// integrals are additive, so neither tile binning nor depth sorting is needed.
+	CHECK_CUDA(FORWARD::render(
+		P,
+		tile_grid,
+		width, height,
+		radii,
+		geomState.means2D,
+		geomState.conic_opacity,
+		geomState.etas,
+		out_color,
+		out_others), debug)
+
+	return P;
+}
+
+// Produce necessary gradients for optimization, corresponding
+// to forward render pass
+void CudaRasterizer::Rasterizer::backward(
+	const int P, int R, 
+	const int width, int height,
+	const float* means3D,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const float* viewmatrix,
+	const float* projmatrix,
+	const float* campos,
+	const float tan_fovx, float tan_fovy,
+	const int* radii,
+	char* geom_buffer,
+	char* binning_buffer,
+	char* img_buffer,
+	const float* dL_dpix,
+	float* dL_dmean2D,
+	float* dL_dconic,
+	float* dL_dopacity,
+	float* dL_deta,
+	float* dL_dmean3D,
+	float* dL_dcov3D,
+	float* dL_dscale,
+	float* dL_drot,
+	const int mode,
+	bool debug)
+{
+	(void)R;
+	(void)binning_buffer;
+	(void)img_buffer;
+	GeometryState geomState = GeometryState::fromChunk(geom_buffer, P);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	const float focal_y = height / (2.0f * tan_fovy);  // tan_fovy=1 when parallel  focal_y = height * (DSD / proj_phy_h)
+	const float focal_x = width / (2.0f * tan_fovx); // tan_fovx=1 when parallel   focal_x = weight * (DSD / proj_phy_w)
+
+	const dim3 tile_grid((width + BLOCK_X - 1) / BLOCK_X, (height + BLOCK_Y - 1) / BLOCK_Y, 1);
+
+	// Compute loss gradients w.r.t. 2D mean position, conic matrix,
+	// opacity and RGB of Gaussians from per-pixel loss gradients.
+	// If we were given precomputed colors and not SHs, use them.
+	CHECK_CUDA(BACKWARD::render(
+		P,
+		tile_grid,
+		width, height,
+		radii,
+		geomState.means2D,
+		geomState.conic_opacity,
+		geomState.etas,
+		dL_dpix,
+		(float3*)dL_dmean2D,
+		(float4*)dL_dconic,
+		dL_dopacity,
+		dL_deta), debug)
+
+	// Take care of the rest of preprocessing. Was the precomputed covariance
+	// given to us or a scales/rot pair? If precomputed, pass that. If not,
+	// use the one we computed ourselves.
+	const float* cov3D_ptr = (cov3D_precomp != nullptr) ? cov3D_precomp : geomState.cov3D;
+	CHECK_CUDA(BACKWARD::preprocess(P, 
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		cov3D_ptr,
+		viewmatrix,
+		projmatrix,
+		focal_x, focal_y,
+		tan_fovx, tan_fovy,
+		(glm::vec3*)campos,
+		(float3*)dL_dmean2D,
+		dL_dconic,
+		dL_deta,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		(glm::vec3*)dL_dscale,
+		(glm::vec4*)dL_drot,
+		mode), debug)
+
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_rasterizer/rasterizer_impl.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include "rasterizer.h"
+#include <cuda_runtime_api.h>
+
+namespace CudaRasterizer
+{
+	template <typename T>
+	static void obtain(char*& chunk, T*& ptr, std::size_t count, std::size_t alignment)
+	{
+		std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
+		ptr = reinterpret_cast<T*>(offset);
+		chunk = reinterpret_cast<char*>(ptr + count);
+	}
+
+	struct GeometryState
+	{
+		int* internal_radii;
+		float2* means2D;
+		float* cov3D;
+		float4* conic_opacity;
+		float* etas;
+
+		static GeometryState fromChunk(char*& chunk, size_t P);
+	};
+
+	template<typename T> 
+	size_t required(size_t P)
+	{
+		char* size = nullptr;
+		T::fromChunk(size, P);
+		return ((size_t)size) + 128;
+	}
+};

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/auxiliary.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/auxiliary.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef cuda_voxelizer_AUXILIARY_H_INCLUDED
+#define cuda_voxelizer_AUXILIARY_H_INCLUDED
+
+#include "config.h"
+#include "stdio.h"
+
+#define BLOCK3D_SIZE (BLOCK3D_X * BLOCK3D_Y * BLOCK3D_Z)
+#define NUM_WARPS3D (BLOCK_SIZE3D/32)
+#define VOXEL_AXUTILITY_GEO_FORWARD 1
+#define VOXEL_AXUTILITY_GEO_BACKWARD 1
+#define GEO_OFFSET 0
+
+
+// struct float7 {
+//     float a, b, c, d, e, f, o;
+
+//     // Default constructor
+//     __host__ __device__ float7() : a(0), b(0), c(0), d(0), e(0), f(0), o(0) {}
+
+//     // Parameterized constructor
+//     __host__ __device__ float7(float a, float b, float c, float d, float e, float f, float o) 
+//     : a(a), b(b), c(c), d(d), e(e), f(f), o(o) {}
+// };
+
+__forceinline__ __device__ void getCube(const float3 p, int max_radius, uint3& cube_min, uint3& cube_max, dim3 grid)
+{
+	cube_min = {
+		min(grid.x, max((int)0, (int)((p.x - max_radius) / BLOCK3D_X))),
+		min(grid.y, max((int)0, (int)((p.y - max_radius) / BLOCK3D_Y))),
+		min(grid.z, max((int)0, (int)((p.z - max_radius) / BLOCK3D_Z)))
+	};
+	cube_max = {
+		min(grid.x, max((int)0, (int)((p.x + max_radius + BLOCK3D_X - 1) / BLOCK3D_X))),
+		min(grid.y, max((int)0, (int)((p.y + max_radius + BLOCK3D_Y - 1) / BLOCK3D_Y))),
+		min(grid.z, max((int)0, (int)((p.z + max_radius + BLOCK3D_Z - 1) / BLOCK3D_Z)))
+	};
+}
+
+__forceinline__ __device__ float3 transformPoint4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float4 transformPoint4x4(const float3& p, const float* matrix)
+{
+	float4 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z + matrix[12],
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z + matrix[13],
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z + matrix[14],
+		matrix[3] * p.x + matrix[7] * p.y + matrix[11] * p.z + matrix[15]
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[4] * p.y + matrix[8] * p.z,
+		matrix[1] * p.x + matrix[5] * p.y + matrix[9] * p.z,
+		matrix[2] * p.x + matrix[6] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float3 transformVec4x3Transpose(const float3& p, const float* matrix)
+{
+	float3 transformed = {
+		matrix[0] * p.x + matrix[1] * p.y + matrix[2] * p.z,
+		matrix[4] * p.x + matrix[5] * p.y + matrix[6] * p.z,
+		matrix[8] * p.x + matrix[9] * p.y + matrix[10] * p.z,
+	};
+	return transformed;
+}
+
+__forceinline__ __device__ float dnormvdz(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+	float dnormvdz = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdz;
+}
+
+__forceinline__ __device__ float3 dnormvdv(float3 v, float3 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float3 dnormvdv;
+	dnormvdv.x = ((+sum2 - v.x * v.x) * dv.x - v.y * v.x * dv.y - v.z * v.x * dv.z) * invsum32;
+	dnormvdv.y = (-v.x * v.y * dv.x + (sum2 - v.y * v.y) * dv.y - v.z * v.y * dv.z) * invsum32;
+	dnormvdv.z = (-v.x * v.z * dv.x - v.y * v.z * dv.y + (sum2 - v.z * v.z) * dv.z) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float4 dnormvdv(float4 v, float4 dv)
+{
+	float sum2 = v.x * v.x + v.y * v.y + v.z * v.z + v.w * v.w;
+	float invsum32 = 1.0f / sqrt(sum2 * sum2 * sum2);
+
+	float4 vdv = { v.x * dv.x, v.y * dv.y, v.z * dv.z, v.w * dv.w };
+	float vdv_sum = vdv.x + vdv.y + vdv.z + vdv.w;
+	float4 dnormvdv;
+	dnormvdv.x = ((sum2 - v.x * v.x) * dv.x - v.x * (vdv_sum - vdv.x)) * invsum32;
+	dnormvdv.y = ((sum2 - v.y * v.y) * dv.y - v.y * (vdv_sum - vdv.y)) * invsum32;
+	dnormvdv.z = ((sum2 - v.z * v.z) * dv.z - v.z * (vdv_sum - vdv.z)) * invsum32;
+	dnormvdv.w = ((sum2 - v.w * v.w) * dv.w - v.w * (vdv_sum - vdv.w)) * invsum32;
+	return dnormvdv;
+}
+
+__forceinline__ __device__ float sigmoid(float x)
+{
+	return 1.0f / (1.0f + expf(-x));
+}
+
+__forceinline__ __device__ bool in_frustum(int idx,
+	const float* orig_points,
+	const float* viewmatrix,
+	const float* projmatrix,
+	bool prefiltered,
+	float3& p_view)
+{
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// Bring points to screen space
+	float4 p_hom = transformPoint4x4(p_orig, projmatrix);
+	float p_w = 1.0f / (p_hom.w + 0.0000001f);
+	float3 p_proj = { p_hom.x * p_w, p_hom.y * p_w, p_hom.z * p_w };
+	p_view = transformPoint4x3(p_orig, viewmatrix);
+
+	if (p_view.z <= 0.2f)// || ((p_proj.x < -1.3 || p_proj.x > 1.3 || p_proj.y < -1.3 || p_proj.y > 1.3)))
+	{
+		if (prefiltered)
+		{
+			printf("Point is filtered although prefiltered is set. This shouldn't happen!");
+			__trap();
+		}
+		return false;
+	}
+	return true;
+}
+
+#define CHECK_CUDA(A, debug) \
+A; if(debug) { \
+auto ret = cudaDeviceSynchronize(); \
+if (ret != cudaSuccess) { \
+std::cerr << "\n[CUDA ERROR] in " << __FILE__ << "\nLine " << __LINE__ << ": " << cudaGetErrorString(ret); \
+throw std::runtime_error(cudaGetErrorString(ret)); \
+} \
+}
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/backward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/backward.cu
@@ -1,0 +1,463 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "backward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+
+// Backward pass for the conversion of scale and rotation to a 
+// 3D covariance matrix for each Gaussian. 
+__device__ void computeCov3D2(int idx, const glm::vec3 scale, float mod, const glm::vec4 rot, const float* dL_dcov3Ds, glm::vec3* dL_dscales, glm::vec4* dL_drots)
+{
+	// Recompute (intermediate) results for the 3D covariance computation.
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 S = glm::mat3(1.0f);
+
+	glm::vec3 s = mod * scale;
+	S[0][0] = s.x;
+	S[1][1] = s.y;
+	S[2][2] = s.z;
+
+	glm::mat3 M = S * R;
+
+	const float* dL_dcov3D = dL_dcov3Ds + 6 * idx;
+
+	glm::vec3 dunc(dL_dcov3D[0], dL_dcov3D[3], dL_dcov3D[5]);
+	glm::vec3 ounc = 0.5f * glm::vec3(dL_dcov3D[1], dL_dcov3D[2], dL_dcov3D[4]);
+
+	// Convert per-element covariance loss gradients to matrix form
+	glm::mat3 dL_dSigma = glm::mat3(
+		dL_dcov3D[0], 0.5f * dL_dcov3D[1], 0.5f * dL_dcov3D[2],
+		0.5f * dL_dcov3D[1], dL_dcov3D[3], 0.5f * dL_dcov3D[4],
+		0.5f * dL_dcov3D[2], 0.5f * dL_dcov3D[4], dL_dcov3D[5]
+	);
+
+	// Compute loss gradient w.r.t. matrix M
+	// dSigma_dM = 2 * M
+	glm::mat3 dL_dM = 2.0f * M * dL_dSigma;
+
+	glm::mat3 Rt = glm::transpose(R);
+	glm::mat3 dL_dMt = glm::transpose(dL_dM);
+
+	// Gradients of loss w.r.t. scale
+	glm::vec3* dL_dscale = dL_dscales + idx;
+	dL_dscale->x = glm::dot(Rt[0], dL_dMt[0]);
+	dL_dscale->y = glm::dot(Rt[1], dL_dMt[1]);
+	dL_dscale->z = glm::dot(Rt[2], dL_dMt[2]);
+
+	dL_dMt[0] *= s.x;
+	dL_dMt[1] *= s.y;
+	dL_dMt[2] *= s.z;
+
+	// Gradients of loss w.r.t. normalized quaternion
+	glm::vec4 dL_dq;
+	dL_dq.x = 2 * z * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * y * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * x * (dL_dMt[1][2] - dL_dMt[2][1]);
+	dL_dq.y = 2 * y * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * z * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * r * (dL_dMt[1][2] - dL_dMt[2][1]) - 4 * x * (dL_dMt[2][2] + dL_dMt[1][1]);
+	dL_dq.z = 2 * x * (dL_dMt[1][0] + dL_dMt[0][1]) + 2 * r * (dL_dMt[2][0] - dL_dMt[0][2]) + 2 * z * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * y * (dL_dMt[2][2] + dL_dMt[0][0]);
+	dL_dq.w = 2 * r * (dL_dMt[0][1] - dL_dMt[1][0]) + 2 * x * (dL_dMt[2][0] + dL_dMt[0][2]) + 2 * y * (dL_dMt[1][2] + dL_dMt[2][1]) - 4 * z * (dL_dMt[1][1] + dL_dMt[0][0]);
+
+	// Gradients of loss w.r.t. unnormalized quaternion
+	float4* dL_drot = (float4*)(dL_drots + idx);
+	*dL_drot = float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w };//dnormvdv(float4{ rot.x, rot.y, rot.z, rot.w }, float4{ dL_dq.x, dL_dq.y, dL_dq.z, dL_dq.w });
+}
+
+__global__ void computeCov3DCUDA(int P,
+	const float3* means,
+	const int* radii,
+	const float* cov3Ds,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float* dL_dconic3D,
+	float3* dL_dmean3D,
+	float* dL_dcov)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	float dVoxel_x = sVoxel_x / (float)nVoxel_x;
+	float dVoxel_y = sVoxel_y / (float)nVoxel_y;
+	float dVoxel_z = sVoxel_z / (float)nVoxel_z;
+	
+	// Reading location of 3D covariance for this Gaussian
+	const float* cov3D = cov3Ds + 6 * idx;
+	float3 mean = means[idx];
+
+	float dL_dconic_a = dL_dconic3D[idx * 6 + 0];
+	float dL_dconic_b = dL_dconic3D[idx * 6 + 1];
+	float dL_dconic_c = dL_dconic3D[idx * 6 + 2];
+	float dL_dconic_d = dL_dconic3D[idx * 6 + 3];
+	float dL_dconic_e = dL_dconic3D[idx * 6 + 4];
+	float dL_dconic_f = dL_dconic3D[idx * 6 + 5];
+
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+	glm::mat3 M = glm::mat3(
+		1.0f / dVoxel_x, 0.0f, 0.0f,
+		0.0f, 1.0f  / dVoxel_y, 0.0f,
+		0.0f, 0.0f, 1.0f / dVoxel_z);
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+
+	float hata = cov[0][0];
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1];
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+	float denom = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	float denom2inv = 1.0f / ((denom * denom) + 0.0000001f);
+
+	float dL_dhata = 0, dL_dhatb = 0, dL_dhatc = 0, dL_dhatd = 0, dL_dhate = 0, dL_dhatf = 0;
+
+	if (denom2inv != 0)
+	{
+		float denom_da = hatd * hatf - hate * hate;
+		float denom_db = 2 * hatc * hate - 2 * hatf * hatb;
+		float denom_dc = 2 * hatb * hate - 2 * hatd * hatc;
+		float denom_dd = hata * hatf - hatc * hatc;
+		float denom_de = 2 * hatb * hatc - 2 * hata * hate;
+		float denom_df = hata * hatd - hatb * hatb;
+		
+		float ce_bf = hatc * hate - hatb * hatf;
+		float be_cd = hatb * hate - hatc * hatd;
+		float bc_ae = hatb * hatc - hata * hate;
+
+		dL_dhata = denom2inv * (-denom_da*denom_da*dL_dconic_a - ce_bf*denom_da*dL_dconic_b - be_cd*denom_da*dL_dconic_c + (hatf*denom-denom_dd*denom_da)*dL_dconic_d + (-hate*denom-bc_ae*denom_da)*dL_dconic_e + (hatd*denom-denom_df*denom_da)*dL_dconic_f);
+		dL_dhatb = denom2inv * (-denom_da*denom_db*dL_dconic_a + (-hatf*denom-ce_bf*denom_db)*dL_dconic_b + (hate*denom-be_cd*denom_db)*dL_dconic_c - denom_dd*denom_db*dL_dconic_d + (hatc*denom-bc_ae*denom_db)*dL_dconic_e + (-2*hatb*denom-denom_df*denom_db)*dL_dconic_f);
+		dL_dhatc = denom2inv * (-denom_da*denom_dc*dL_dconic_a + (hate*denom-ce_bf*denom_dc)*dL_dconic_b + (-hatd*denom-be_cd*denom_dc)*dL_dconic_c + (-2*hatc*denom-denom_dd*denom_dc)*dL_dconic_d + (hatb*denom-bc_ae*denom_dc)*dL_dconic_e - denom_df*denom_dc*dL_dconic_f);
+		dL_dhatd = denom2inv * ((hatf*denom-denom_da*denom_dd)*dL_dconic_a - ce_bf*denom_dd*dL_dconic_b +(-hatc*denom-be_cd*denom_dd)*dL_dconic_c - denom_dd*denom_dd*dL_dconic_d - bc_ae*denom_dd*dL_dconic_e + (hata*denom-denom_df*denom_dd)*dL_dconic_f);
+		dL_dhate = denom2inv * ((-2*hate*denom-denom_da*denom_de)*dL_dconic_a + (hatc*denom-ce_bf*denom_de)*dL_dconic_b + (hatb*denom-be_cd*denom_de)*dL_dconic_c - denom_dd*denom_de*dL_dconic_d + (-hata*denom-bc_ae*denom_de)*dL_dconic_e + -denom_df*denom_de*dL_dconic_f);
+		dL_dhatf = denom2inv * ((hatd*denom-denom_da*denom_df)*dL_dconic_a + (-hatb*denom-ce_bf*denom_df)*dL_dconic_b - be_cd*denom_df*dL_dconic_c + (hata*denom-denom_dd*denom_df)*dL_dconic_d - bc_ae*denom_df*dL_dconic_e - denom_df*denom_df*dL_dconic_f);
+
+		// Gradients of loss L w.r.t. each 3D covariance matrix (Vrk) entry
+		// dL_da
+		dL_dcov[6 * idx + 0] += M[0][0]*M[0][0]*dL_dhata + M[0][0]*M[1][0]*dL_dhatb + M[0][0]*M[2][0]*dL_dhatc + M[1][0]*M[1][0]*dL_dhatd + M[1][0]*M[2][0]*dL_dhate + M[2][0]*M[2][0]*dL_dhatf;
+		// dL_dd
+		dL_dcov[6 * idx + 3] += M[0][1]*M[0][1]*dL_dhata + M[0][1]*M[1][1]*dL_dhatb + M[0][1]*M[2][1]*dL_dhatc + M[1][1]*M[1][1]*dL_dhatd + M[1][1]*M[2][1]*dL_dhate + M[2][1]*M[2][1]*dL_dhatf;
+		// dL_df
+		dL_dcov[6 * idx + 5] += M[0][2]*M[0][2]*dL_dhata + M[0][2]*M[1][2]*dL_dhatb + M[0][2]*M[2][2]*dL_dhatc + M[1][2]*M[1][2]*dL_dhatd + M[1][2]*M[2][2]*dL_dhate + M[2][2]*M[2][2]*dL_dhatf;
+		
+		// dL_db
+		dL_dcov[6 * idx + 1] += 2*M[0][0]*M[0][1]*dL_dhata + (M[0][1]*M[1][0]+M[0][0]*M[1][1])*dL_dhatb + (M[0][1]*M[2][0]+M[0][0]*M[2][1])*dL_dhatc + 2*M[1][0]*M[1][1]*dL_dhatd + (M[1][1]*M[2][0]+M[1][0]*M[2][1])*dL_dhate + 2*M[2][0]*M[2][1]*dL_dhatf;
+		// dL_dc
+		dL_dcov[6 * idx + 2] += 2*M[0][0]*M[0][2]*dL_dhata + (M[0][2]*M[1][0]+M[0][0]*M[1][2])*dL_dhatb + (M[0][2]*M[2][0]+M[0][0]*M[2][2])*dL_dhatc + 2*M[1][0]*M[1][2]*dL_dhatd + (M[1][2]*M[2][0]+M[1][0]*M[2][2])*dL_dhate + 2*M[2][0]*M[2][2]*dL_dhatf;
+		// dL_de
+		dL_dcov[6 * idx + 4] += 2*M[0][1]*M[0][2]*dL_dhata + (M[0][2]*M[1][1]+M[0][1]*M[1][2])*dL_dhatb + (M[0][2]*M[2][1]+M[0][1]*M[2][2])*dL_dhatc + 2*M[1][1]*M[1][2]*dL_dhatd + (M[1][2]*M[2][1]+M[1][1]*M[2][2])*dL_dhate + 2*M[2][1]*M[2][2]*dL_dhatf;
+	}
+	else
+	{
+		for (int i = 0; i < 6; i++)
+			dL_dcov[6 * idx + i] = 0;
+	}
+}
+
+
+template<int C>
+__global__ void preprocessCUDA(
+	int P,
+	const float3* means,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float3* dL_dmean3D_norm,
+	glm::vec3* dL_dmeans,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P || !(radii[idx] > 0))
+		return;
+
+	glm::vec3 dL_dmean;
+	dL_dmean.x = dL_dmean3D_norm[idx].x;
+	dL_dmean.y = dL_dmean3D_norm[idx].y;
+	dL_dmean.z = dL_dmean3D_norm[idx].z;
+
+	// printf("dL_dmean.x: %f\n", dL_dmean.x);
+	// printf("dL_dmean.y: %f\n", dL_dmean.y);
+	// printf("dL_dmean.z: %f\n", dL_dmean.z);
+	
+	dL_dmeans[idx] += dL_dmean;
+
+	// Compute gradient updates due to computing covariance from scale/rotation
+	if (scales)
+		computeCov3D2(idx, scales[idx], scale_modifier, rotations[idx], dL_dcov3D, dL_dscale, dL_drot);
+
+}
+
+// Backward version of the rendering procedure.
+template <uint32_t C>
+__global__ void __launch_bounds__(BLOCK3D_X * BLOCK3D_Y * BLOCK3D_Z)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float3* __restrict__ points_xyz_vol,
+	const float* __restrict__ conic_opacity,
+	const uint32_t* __restrict__ n_contrib,
+	const float* __restrict__ dL_dpixels,
+	const float* __restrict__ dL_dothers,
+	float3* __restrict__ dL_dmean3D_norm,
+	float* __restrict__ dL_dconic3D,
+	float* __restrict__ dL_dopacity)
+{
+	auto block = cg::this_thread_block();
+
+	float dVoxel_x = sVoxel_x / (float)nVoxel_x;
+	float dVoxel_y = sVoxel_y / (float)nVoxel_y;
+	float dVoxel_z = sVoxel_z / (float)nVoxel_z;
+
+	uint32_t horizontal_blocks1 = (nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X;
+	uint32_t horizontal_blocks2 = (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y;
+	uint3 voxel_min = { block.group_index().x * BLOCK3D_X, block.group_index().y * BLOCK3D_Y,  block.group_index().z * BLOCK3D_Z};
+	uint3 voxel_max = { min(voxel_min.x + BLOCK3D_X, nVoxel_x), min(voxel_min.y + BLOCK3D_Y , nVoxel_y),  min(voxel_min.z + BLOCK3D_Z , nVoxel_z)};
+	uint3 voxel = { voxel_min.x + block.thread_index().x, voxel_min.y + block.thread_index().y, voxel_min.z + block.thread_index().z};
+	uint32_t voxel_id = nVoxel_z * nVoxel_y * voxel.x + nVoxel_z * voxel.y + voxel.z;
+	// add 0.5 because we donnot count offset previously, like gs code in ndc2pixel()
+	float3 voxelf = { (float)voxel.x + 0.5f, (float)voxel.y + 0.5f, (float)voxel.z + 0.5f};
+
+	// Check if this thread is associated with a valid pixel or outside.
+	bool inside = voxel.x < nVoxel_x && voxel.y < nVoxel_y && voxel.z < nVoxel_z;
+	// Done threads can help with fetching, but don't rasterize
+	bool done = !inside;
+
+	// Load start/end range of IDs to process in bit sorted list.
+	uint2 range = ranges[block.group_index().z * horizontal_blocks2 * horizontal_blocks1 + block.group_index().y * horizontal_blocks1 + block.group_index().x];
+	const int rounds = ((range.y - range.x + BLOCK3D_SIZE - 1) / BLOCK3D_SIZE);
+	int toDo = range.y - range.x;
+
+	// Allocate storage for batches of collectively fetched data.
+	__shared__ int collected_id[BLOCK3D_SIZE];
+	__shared__ float3 collected_xyz[BLOCK3D_SIZE];
+	__shared__ float collected_conic_a[BLOCK3D_SIZE];
+	__shared__ float collected_conic_b[BLOCK3D_SIZE];
+	__shared__ float collected_conic_c[BLOCK3D_SIZE];
+	__shared__ float collected_conic_d[BLOCK3D_SIZE];
+	__shared__ float collected_conic_e[BLOCK3D_SIZE];
+	__shared__ float collected_conic_f[BLOCK3D_SIZE];
+	__shared__ float collected_o[BLOCK3D_SIZE];
+
+	// We start from the back. The ID of the last contributing
+	// Gaussian is known from each pixel from the forward.
+	uint32_t contributor = toDo;
+	const int last_contributor = inside ? n_contrib[voxel_id] : 0;
+
+	float dL_dpixel[C];
+	if (inside)
+		for (int i = 0; i < C; i++)
+			dL_dpixel[i] = dL_dpixels[i *  nVoxel_x * nVoxel_y * nVoxel_z + voxel_id];
+	
+	#if VOXEL_AXUTILITY_GEO_BACKWARD
+		float dL_dgeo;
+		if (inside)
+			dL_dgeo = dL_dothers[GEO_OFFSET * nVoxel_x * nVoxel_y * nVoxel_z + voxel_id];
+	#endif
+	
+	// Gradient of pixel coordinate w.r.t. normalized 
+	// screen-space viewport corrdinates (-1 to 1)
+	const float ddelx_dx = dVoxel_x;
+	const float ddely_dy = dVoxel_y;
+	const float ddelz_dz = dVoxel_z;
+
+	// Traverse all Gaussians
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK3D_SIZE)
+	{
+		// Load auxiliary data into shared memory, start in the BACK
+		// and load them in revers order.
+		block.sync();
+		const int progress = i * BLOCK3D_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			const int coll_id = point_list[range.y - progress - 1];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xyz[block.thread_rank()] = points_xyz_vol[coll_id];
+			collected_conic_a[block.thread_rank()] = conic_opacity[coll_id * 7 + 0];
+			collected_conic_b[block.thread_rank()] = conic_opacity[coll_id * 7 + 1];
+			collected_conic_c[block.thread_rank()] = conic_opacity[coll_id * 7 + 2];
+			collected_conic_d[block.thread_rank()] = conic_opacity[coll_id * 7 + 3];
+			collected_conic_e[block.thread_rank()] = conic_opacity[coll_id * 7 + 4];
+			collected_conic_f[block.thread_rank()] = conic_opacity[coll_id * 7 + 5];
+			collected_o[block.thread_rank()] = conic_opacity[coll_id * 7 + 6];
+		}
+		block.sync();
+
+		// Iterate over Gaussians
+		for (int j = 0; !done && j < min(BLOCK3D_SIZE, toDo); j++)
+		{
+			// Keep track of current Gaussian ID. Skip, if this one
+			// is behind the last contributor for this pixel.
+			contributor--;
+			if (contributor >= last_contributor)
+				continue;
+
+			// Compute blending values, as before.
+
+			float3 xyz = collected_xyz[j];
+			float3 d = { xyz.x - voxelf.x, xyz.y - voxelf.y, xyz.z - voxelf.z };
+			float conic_a = collected_conic_a[j];
+			float conic_b = collected_conic_b[j];
+			float conic_c = collected_conic_c[j];
+			float conic_d = collected_conic_d[j];
+			float conic_e = collected_conic_e[j];
+			float conic_f = collected_conic_f[j];
+			float opa = collected_o[j];
+
+			float power = - 0.5 * (conic_a * d.x * d.x + conic_d * d.y * d.y + conic_f * d.z * d.z) - conic_b * d.x * d.y - conic_c * d.x * d.z - conic_e * d.y * d.z;
+
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			float alpha = opa * G;
+			float dL_dG = 0;
+			#if VOXEL_AXUTILITY_GEO_BACKWARD	
+				//*** propagate gradients of geo reg term ***//
+				dL_dG += dL_dgeo;
+			#endif				
+
+			if (alpha < 0.000001f)
+				continue;
+			
+			// Propagate gradients to per-Gaussian colors and keep
+			// gradients w.r.t. alpha (blending factor for a Gaussian/pixel
+			// pair).
+			// Since we are simple sum, dchannel_dalpha = 1.0
+			float dL_dalpha = 0.0f;
+			const int global_id = collected_id[j];
+			for (int ch = 0; ch < C; ch++)
+			{
+				const float dL_dchannel = dL_dpixel[ch];
+				dL_dalpha += 1.0f * dL_dchannel;
+			}
+
+			// Helpful reusable temporary variables
+			dL_dG += opa * dL_dalpha;
+			const float gdx = G * d.x;
+			const float gdy = G * d.y;
+			const float gdz = G * d.z;
+			const float dG_ddelx = - conic_a * gdx - conic_b * gdy - conic_c * gdz;
+			const float dG_ddely = - conic_d * gdy - conic_b * gdx - conic_e * gdz;
+			const float dG_ddelz = - conic_f * gdz - conic_c * gdx - conic_e * gdy;
+
+			atomicAdd(&dL_dmean3D_norm[global_id].x, dL_dG * dG_ddelx * ddelx_dx); // ddelx_dx is used to compensate ndc2pix
+			atomicAdd(&dL_dmean3D_norm[global_id].y, dL_dG * dG_ddely * ddely_dy); // ddelx_dx is used to compensate ndc2pix
+			atomicAdd(&dL_dmean3D_norm[global_id].z, dL_dG * dG_ddelz * ddelz_dz); // ddelx_dx is used to compensate ndc2pix
+
+			atomicAdd(&dL_dconic3D[global_id * 6 + 0], - 0.5 * gdx * d.x * dL_dG);  // conic_a
+			atomicAdd(&dL_dconic3D[global_id * 6 + 1], - 1.0 * gdx * d.y * dL_dG);  // conic_b
+			atomicAdd(&dL_dconic3D[global_id * 6 + 2], - 1.0 * gdx * d.z * dL_dG);  // conic_c
+			atomicAdd(&dL_dconic3D[global_id * 6 + 3], - 0.5 * gdy * d.y * dL_dG);  // conic_d
+			atomicAdd(&dL_dconic3D[global_id * 6 + 4], - 1.0 * gdy * d.z * dL_dG);  // conic_e
+			atomicAdd(&dL_dconic3D[global_id * 6 + 5], - 0.5 * gdz * d.z * dL_dG);  // conic_f
+
+			atomicAdd(&dL_dopacity[global_id], G * dL_dalpha);
+		}
+	}
+	
+}
+
+
+void BACKWARD::preprocess(
+	int P,
+	const float3* means3D,
+	const int* radii,
+	const glm::vec3* scales,
+	const glm::vec4* rotations,
+	const float scale_modifier,
+	const float* cov3Ds,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float3* dL_dmean3D_norm,
+	const float* dL_dconic3D,
+	glm::vec3* dL_dmean3D,
+	float* dL_dcov3D,
+	glm::vec3* dL_dscale,
+	glm::vec4* dL_drot)
+{
+	computeCov3DCUDA << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		radii,
+		cov3Ds,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		dL_dconic3D,
+		(float3*)dL_dmean3D,
+		dL_dcov3D);
+
+	preprocessCUDA<NUM_CHANNELS> << < (P + 255) / 256, 256 >> > (
+		P,
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		(float3*)dL_dmean3D_norm,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		dL_dscale,
+		dL_drot);
+
+}
+
+void BACKWARD::render(
+	const dim3 grid, const dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float3* means3D_norm,
+	const float* conic_opacity,
+	const uint32_t* n_contrib,
+	const float* dL_dpixels,
+	const float* dL_dothers,
+	float3* dL_dmean3D_norm,
+	float* dL_dconic3D,
+	float* dL_dopacity
+	)
+{
+	renderCUDA<NUM_CHANNELS> << <grid, block >> >(
+		ranges,
+		point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		means3D_norm,
+		conic_opacity,
+		n_contrib,
+		dL_dpixels,
+		dL_dothers,
+		dL_dmean3D_norm,
+		dL_dconic3D,
+		dL_dopacity
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/backward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/backward.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef cuda_voxelizer_BACKWARD_H_INCLUDED
+#define cuda_voxelizer_BACKWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+
+namespace BACKWARD
+{
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+		const float3* means3D_norm,
+		const float* conic_opacity,
+		const uint32_t* n_contrib,
+		const float* dL_dpixels,
+		const float* dL_dothers,
+		float3* dL_dmean3D_norm,
+		float* dL_dconic3D,
+		float* dL_dopacity);
+
+	void preprocess(
+		int P,
+		const float3* means,
+		const int* radii,
+		const glm::vec3* scales,
+		const glm::vec4* rotations,
+		const float scale_modifier,
+		const float* cov3Ds,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+		const float center_x, float center_y, float center_z,
+		const float3* dL_dmean3D_norm,
+		const float* dL_dconic3D,
+		glm::vec3* dL_dmean3D,
+		float* dL_dcov3D,
+		glm::vec3* dL_dscale,
+		glm::vec4* dL_drot);
+}
+
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/config.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/config.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef cuda_voxelizer_CONFIG_H_INCLUDED
+#define cuda_voxelizer_CONFIG_H_INCLUDED
+
+#define NUM_CHANNELS 1
+#define BLOCK3D_X 8
+#define BLOCK3D_Y 8
+#define BLOCK3D_Z 8
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/forward.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/forward.cu
@@ -1,0 +1,391 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+#include <stdio.h> // for debug
+#include "forward.h"
+#include "auxiliary.h"
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+// Forward method for converting scale and rotation properties of each
+// Gaussian to a 3D covariance matrix in world space. Also takes care
+// of quaternion normalization.
+__device__ void computeCov3D2(const glm::vec3 scale, float mod, const glm::vec4 rot, float* cov3D)
+{
+	// Create scaling matrix
+	glm::mat3 S = glm::mat3(1.0f);
+	S[0][0] = mod * scale.x;
+	S[1][1] = mod * scale.y;
+	S[2][2] = mod * scale.z;
+
+	// Normalize quaternion to get valid rotation
+	glm::vec4 q = rot;// / glm::length(rot);
+	float r = q.x;
+	float x = q.y;
+	float y = q.z;
+	float z = q.w;
+
+	// Compute rotation matrix from quaternion
+	glm::mat3 R = glm::mat3(
+		1.f - 2.f * (y * y + z * z), 2.f * (x * y - r * z), 2.f * (x * z + r * y),
+		2.f * (x * y + r * z), 1.f - 2.f * (x * x + z * z), 2.f * (y * z - r * x),
+		2.f * (x * z - r * y), 2.f * (y * z + r * x), 1.f - 2.f * (x * x + y * y)
+	);
+
+	glm::mat3 M = S * R;
+
+	// Compute 3D world covariance matrix Sigma
+	glm::mat3 Sigma = glm::transpose(M) * M;
+
+	// Covariance is symmetric, only store upper right
+	cov3D[0] = Sigma[0][0];  // a
+	cov3D[1] = Sigma[0][1];  // b
+	cov3D[2] = Sigma[0][2];  // c
+	cov3D[3] = Sigma[1][1];  // d
+	cov3D[4] = Sigma[1][2];  // e
+	cov3D[5] = Sigma[2][2];  // f
+}
+
+
+template<int C>
+__global__ void preprocessCUDA(int P,
+	const float* orig_points,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	int* radii,
+	float3* points_xyz_vol,
+	float* depths,
+	float* cov3Ds,
+	float* conic_opacity,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered
+	)
+{
+    auto idx = cg::this_grid().thread_rank(); // idx
+	if (idx >= P)
+		return;
+
+	// printf("Now in preprocessCUDA\n");
+
+	// Initialize radius and touched tiles to 0. If this isn't changed,
+	// this Gaussian will not be processed further.
+	radii[idx] = 0;
+	tiles_touched[idx] = 0;
+
+	float dVoxel_x = sVoxel_x / (float)nVoxel_x;
+	float dVoxel_y = sVoxel_y / (float)nVoxel_y;
+	float dVoxel_z = sVoxel_z / (float)nVoxel_z;
+
+	float3 p_orig = { orig_points[3 * idx], orig_points[3 * idx + 1], orig_points[3 * idx + 2] };
+
+	// If 3D covariance matrix is precomputed, use it, otherwise compute
+	// from scaling and rotation parameters. 
+	const float* cov3D;
+	if (cov3D_precomp != nullptr)
+	{
+		cov3D = cov3D_precomp + idx * 6;
+	}
+	else
+	{
+		computeCov3D2(scales[idx], scale_modifier, rotations[idx], cov3Ds + idx * 6);
+		cov3D = cov3Ds + idx * 6;
+	}
+
+	// Transfer to voxel space
+	glm::mat3 Vrk = glm::mat3(
+		cov3D[0], cov3D[1], cov3D[2],
+		cov3D[1], cov3D[3], cov3D[4],
+		cov3D[2], cov3D[4], cov3D[5]);
+	glm::mat3 M = glm::mat3(
+		1.f / dVoxel_x, 0.0f, 0.0f,
+		0.0f, 1.f  / dVoxel_y, 0.0f,
+		0.0f, 0.0f, 1.f / dVoxel_z);
+	glm::mat3 cov = glm::transpose(M) * glm::transpose(Vrk) * M;
+	
+	float hata = cov[0][0];
+	float hatb = cov[0][1];
+	float hatc = cov[0][2];
+	float hatd = cov[1][1];
+	float hate = cov[1][2];
+	float hatf = cov[2][2];
+	float det = hata * hatd * hatf + 2 * hatb * hatc * hate - hata * hate * hate - hatf * hatb * hatb - hatd * hatc * hatc;
+	if (det == 0.0f)
+		return;
+	float det_inv = 1.f / det;
+	float inv_a = (hatd * hatf - hate * hate) * det_inv;
+	float inv_b = (hatc * hate - hatb * hatf) * det_inv;
+	float inv_c = (hatb * hate - hatc * hatd) * det_inv;
+	float inv_d = (hata * hatf - hatc * hatc) * det_inv;
+	float inv_e = (hatb * hatc - hata * hate) * det_inv;
+	float inv_f = (hata * hatd - hatb * hatb) * det_inv;
+
+	// printf("inv_a: %f, inv_b: %f, inv_c: %f, inv_d: %f, inv_e: %f, inv_f: %f\n", inv_a, inv_b, inv_c, inv_d, inv_e, inv_f);
+	// glm::mat3 cov_inv = glm::inverse(cov);
+	// printf("cov_inv:\n");
+	// printf("%f\t%f\t%f\n", cov_inv[0][0], cov_inv[0][1], cov_inv[0][2]);
+	// printf("%f\t%f\t%f\n", cov_inv[1][0], cov_inv[1][1], cov_inv[1][2]);
+	// printf("%f\t%f\t%f\n", cov_inv[2][0], cov_inv[2][1], cov_inv[2][2]);
+
+	glm::vec3 scale = scales[idx];
+	float max_scale = max(max(scale.x / dVoxel_x, scale.y/ dVoxel_y), scale.z/ dVoxel_z); 
+	float my_radius = ceil(3.f * max_scale);
+
+	float3 point_vol = {(p_orig.x - center_x + sVoxel_x / 2) / dVoxel_x, 
+						(p_orig.y - center_y + sVoxel_y / 2) / dVoxel_y,
+						(p_orig.z - center_z + sVoxel_z / 2) / dVoxel_z};
+
+
+	if (point_vol.x < 0 || point_vol.y < 0 || point_vol.z < 0 || point_vol.x > (float)nVoxel_x || point_vol.y > (float)nVoxel_y || point_vol.z > (float)nVoxel_z)
+	{
+		return;
+	}
+
+	uint3 cube_min, cube_max;
+	getCube(point_vol, my_radius, cube_min, cube_max, grid);
+
+	if ((cube_max.x - cube_min.x) * (cube_max.y - cube_min.y) * (cube_max.z - cube_min.z) == 0)
+		return;
+	
+	radii[idx] = my_radius;
+	tiles_touched[idx] = (cube_max.z - cube_min.z) * (cube_max.y - cube_min.y) * (cube_max.x - cube_min.x);
+	depths[idx] = p_orig.z;  // just give a value
+	points_xyz_vol[idx] = point_vol;
+	conic_opacity[idx * 7 + 0] = inv_a;
+	conic_opacity[idx * 7 + 1] = inv_b;
+	conic_opacity[idx * 7 + 2] = inv_c;
+	conic_opacity[idx * 7 + 3] = inv_d;
+	conic_opacity[idx * 7 + 4] = inv_e;
+	conic_opacity[idx * 7 + 5] = inv_f;
+	conic_opacity[idx * 7 + 6] = opacities[idx];
+}
+
+// Main rasterization method. Collaboratively works on one tile per
+// block, each thread treats one pixel. Alternates between fetching 
+// and rasterizing data.
+template <uint32_t CHANNELS>
+__global__ void __launch_bounds__(BLOCK3D_X * BLOCK3D_Y * BLOCK3D_Z)
+renderCUDA(
+	const uint2* __restrict__ ranges,
+	const uint32_t* __restrict__ point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float3* __restrict__ points_xyz_vol,
+	const float* __restrict__ conic_opacity,
+	uint32_t* __restrict__ n_contrib,
+	float* __restrict__ out_volume,
+	float* __restrict__ out_others 
+	)
+{
+	
+	// Identify current tile and associated min/max pixel range.
+	auto block = cg::this_thread_block();
+
+	uint32_t horizontal_blocks1 = (nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X;
+	uint32_t horizontal_blocks2 = (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y;
+	uint3 voxel_min = { block.group_index().x * BLOCK3D_X, block.group_index().y * BLOCK3D_Y,  block.group_index().z * BLOCK3D_Z};
+	uint3 voxel_max = { min(voxel_min.x + BLOCK3D_X, nVoxel_x), min(voxel_min.y + BLOCK3D_Y , nVoxel_y),  min(voxel_min.z + BLOCK3D_Z , nVoxel_z)};
+	uint3 voxel = { voxel_min.x + block.thread_index().x, voxel_min.y + block.thread_index().y, voxel_min.z + block.thread_index().z};
+	uint32_t voxel_id = nVoxel_z * nVoxel_y * voxel.x + nVoxel_z * voxel.y + voxel.z;
+	// add 0.5 because we donnot count offset previously, like gs code in ndc2pixel()
+	float3 voxelf = { (float)voxel.x + 0.5f, (float)voxel.y + 0.5f, (float)voxel.z + 0.5f};
+
+	// Check if this thread is associated with a valid pixel or outside.
+	bool inside = voxel.x < nVoxel_x && voxel.y < nVoxel_y && voxel.z < nVoxel_z;
+	// Done threads can help with fetching, but don't rasterize
+	bool done = !inside;
+
+	// Load start/end range of IDs to process in bit sorted list.
+	uint2 range = ranges[block.group_index().z * horizontal_blocks2 * horizontal_blocks1 + block.group_index().y * horizontal_blocks1 + block.group_index().x];
+	const int rounds = ((range.y - range.x + BLOCK3D_SIZE - 1) / BLOCK3D_SIZE);
+	int toDo = range.y - range.x;
+
+	// Allocate storage for batches of collectively fetched data.
+	__shared__ int collected_id[BLOCK3D_SIZE];
+	__shared__ float3 collected_xyz[BLOCK3D_SIZE];
+	__shared__ float collected_conic_a[BLOCK3D_SIZE];
+	__shared__ float collected_conic_b[BLOCK3D_SIZE];
+	__shared__ float collected_conic_c[BLOCK3D_SIZE];
+	__shared__ float collected_conic_d[BLOCK3D_SIZE];
+	__shared__ float collected_conic_e[BLOCK3D_SIZE];
+	__shared__ float collected_conic_f[BLOCK3D_SIZE];
+	__shared__ float collected_o[BLOCK3D_SIZE];
+
+	// Initialize helper variables
+	uint32_t contributor = 0;
+	uint32_t last_contributor = 0;
+	float C[CHANNELS] = { 0 };
+
+	#if VOXEL_AXUTILITY_GEO_FORWARD
+		float geo = {0};
+	#endif
+
+	// Iterate over batches until all done or range is complete
+	for (int i = 0; i < rounds; i++, toDo -= BLOCK3D_SIZE)
+	{
+		// End if entire block votes that it is done rasterizing
+		int num_done = __syncthreads_count(done);
+		if (num_done == BLOCK3D_SIZE)
+			break;
+
+		// Collectively fetch per-Gaussian data from global to shared
+		int progress = i * BLOCK3D_SIZE + block.thread_rank();
+		if (range.x + progress < range.y)
+		{
+			int coll_id = point_list[range.x + progress];
+			collected_id[block.thread_rank()] = coll_id;
+			collected_xyz[block.thread_rank()] = points_xyz_vol[coll_id];
+			collected_conic_a[block.thread_rank()] = conic_opacity[coll_id * 7 + 0];
+			collected_conic_b[block.thread_rank()] = conic_opacity[coll_id * 7 + 1];
+			collected_conic_c[block.thread_rank()] = conic_opacity[coll_id * 7 + 2];
+			collected_conic_d[block.thread_rank()] = conic_opacity[coll_id * 7 + 3];
+			collected_conic_e[block.thread_rank()] = conic_opacity[coll_id * 7 + 4];
+			collected_conic_f[block.thread_rank()] = conic_opacity[coll_id * 7 + 5];
+			collected_o[block.thread_rank()] = conic_opacity[coll_id * 7 + 6];
+		}
+		block.sync();
+		
+		// Iterate over current batch
+		for (int j = 0; !done && j < min(BLOCK3D_SIZE, toDo); j++)
+		{
+			// Keep track of current position in range
+			contributor++;
+			float3 xyz = collected_xyz[j];
+			float3 d = { xyz.x - voxelf.x, xyz.y - voxelf.y, xyz.z - voxelf.z };
+			float conic_a = collected_conic_a[j];
+			float conic_b = collected_conic_b[j];
+			float conic_c = collected_conic_c[j];
+			float conic_d = collected_conic_d[j];
+			float conic_e = collected_conic_e[j];
+			float conic_f = collected_conic_f[j];
+			float opa = collected_o[j];
+
+			float power = - 0.5 * (conic_a * d.x * d.x + conic_d * d.y * d.y + conic_f * d.z * d.z) - conic_b * d.x * d.y - conic_c * d.x * d.z - conic_e * d.y * d.z;
+			
+			// printf("conic_a: %f\n", conic_a);
+			// printf("conic_b: %f\n", conic_b);
+			// printf("conic_c: %f\n", conic_c);
+			// printf("conic_d: %f\n", conic_d);
+			// printf("conic_e: %f\n", conic_e);
+			// printf("conic_f: %f\n", conic_f);
+			// printf("opa: %f\n", opa);
+			// printf("xyz.x: %f, xyz.y: %f, xyz.z: %f\n", xyz.x, xyz.y, xyz.z);
+			// printf("voxelf.x: %f, voxelf.y: %f, voxelf.z: %f\n", voxelf.x, voxelf.y, voxelf.z);
+			// printf("d.x: %f, d.y: %f, d.z: %f\n", d.x, d.y, d.z);
+			// printf("power: %f\n", power);
+
+			if (power > 0.0f)
+				continue;
+
+			const float G = exp(power);
+			#if VOXEL_AXUTILITY_GEO_FORWARD
+				geo += G;
+			#endif
+			float alpha = opa * G;
+			if (alpha < 0.000001f)
+				continue;
+
+			// Simply add all alphas
+			for (int ch = 0; ch < CHANNELS; ch++)
+				C[ch] += alpha;
+			
+			// Keep track of last range entry to update this
+			// pixel.
+			last_contributor = contributor;
+		}
+		
+	}
+
+	// All threads that treat valid pixel write out their final
+	// rendering data to the frame and auxiliary buffers.
+	if (inside)
+	{
+		n_contrib[voxel_id] = last_contributor;
+		for (int ch = 0; ch < CHANNELS; ch++)
+			out_volume[ch * nVoxel_x * nVoxel_y * nVoxel_z + voxel_id] = C[ch];
+		#if VOXEL_AXUTILITY_GEO_FORWARD
+			out_others[GEO_OFFSET * nVoxel_x * nVoxel_y * nVoxel_z + voxel_id] = geo;
+		#endif
+	}
+}
+
+void FORWARD::render(
+	const dim3 grid, dim3 block,
+	const uint2* ranges,
+	const uint32_t* point_list,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float3* means3D_norm,
+	const float* conic_opacity,
+	uint32_t* n_contrib,
+	float* out_volume,
+	float* out_others
+	)
+{
+	renderCUDA<NUM_CHANNELS> << <grid, block >> > (
+		ranges,
+		point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		means3D_norm,
+		conic_opacity,
+		n_contrib,
+		out_volume,
+		out_others
+		);
+	
+}
+
+
+void FORWARD::preprocess(int P,
+	const float* means3D,
+	const glm::vec3* scales,
+	const float scale_modifier,
+	const glm::vec4* rotations,
+	const float* opacities,
+	const float* cov3D_precomp,
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	int* radii,
+	float3* means3D_norm,
+	float* depths,
+	float* cov3Ds,
+	float* conic_opacity,
+	const dim3 grid,
+	uint32_t* tiles_touched,
+	bool prefiltered
+	)
+{	
+	preprocessCUDA<NUM_CHANNELS> << <(P + 255) / 256, 256 >> > (
+		P,
+		means3D,
+		scales,
+		scale_modifier,
+		rotations,
+		opacities,
+		cov3D_precomp,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		radii,
+		means3D_norm,
+		depths,
+		cov3Ds,
+		conic_opacity,
+		grid,
+		tiles_touched,
+		prefiltered
+		);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/forward.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/forward.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#ifndef cuda_voxelizer_FORWARD_H_INCLUDED
+#define cuda_voxelizer_FORWARD_H_INCLUDED
+
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+namespace FORWARD
+{
+	// Perform initial steps for each Gaussian prior to rasterization.
+	void preprocess(int P,
+		const float* orig_points,
+		const glm::vec3* scales,
+		const float scale_modifier,
+		const glm::vec4* rotations,
+		const float* opacities,
+		const float* cov3D_precomp,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+		const float center_x, float center_y, float center_z,
+		int* radii,
+		float3* means3D_norm,
+		float* depths,
+		float* cov3Ds,
+		float* conic_opacity,
+		const dim3 grid,
+		uint32_t* tiles_touched,
+		bool prefiltered
+		);
+
+	// Main rasterization method.
+	void render(
+		const dim3 grid, dim3 block,
+		const uint2* ranges,
+		const uint32_t* point_list,
+		const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+		const float3* means3D_norm,
+		const float* conic_opacity,
+		uint32_t* n_contrib,
+		float* out_volume,
+		float* out_others
+		);
+}
+
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/voxelizer.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/voxelizer.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ * 
+ * Modified from code base https://github.com/graphdeco-inria/diff-gaussian-rasterization
+ * by Tao Jun Lin
+ * 
+ */
+
+#ifndef cuda_voxelizer_H_INCLUDED
+#define cuda_voxelizer_H_INCLUDED
+
+#include <vector>
+#include <functional>
+
+namespace CudaVoxelizer
+{
+    class Voxelizer
+	{
+	public:
+
+		static int forward(
+			std::function<char* (size_t)> geometryBuffer,
+			std::function<char* (size_t)> binningBuffer,
+			std::function<char* (size_t)> imageBuffer,
+			const int P,
+			const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+			const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+			const float center_x, float center_y, float center_z,
+			const float* means3D,
+			const float* opacities,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const bool prefiltered,
+			float* out_volume,
+			float* out_others,
+			int* radii = nullptr,
+			bool debug = false);
+
+		static void backward(
+			const int P, int R, 
+			const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+			const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+			const float center_x, float center_y, float center_z,
+			const float* means3D,
+			const float* scales,
+			const float scale_modifier,
+			const float* rotations,
+			const float* cov3D_precomp,
+			const int* radii,
+			char* geom_buffer,
+			char* binning_buffer,
+			char* img_buffer,
+			const float* dL_dpix,
+			const float* dL_dothers,
+			float* dL_dmean3D_norm,
+			float* dL_dconic3D,
+			float* dL_dopacity,
+			float* dL_dmean3D,
+			float* dL_dcov3D,
+			float* dL_dscale,
+			float* dL_drot,
+			bool debug);
+	};
+
+};
+
+#endif

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/voxelizer_impl.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/voxelizer_impl.cu
@@ -1,0 +1,364 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include "voxelizer_impl.h"
+#include <iostream>
+#include <fstream>
+#include <algorithm>
+#include <numeric>
+#include <cuda.h>
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#include <cub/cub.cuh>
+#include <cub/device/device_radix_sort.cuh>
+#define GLM_FORCE_CUDA
+#include <glm/glm.hpp>
+
+#include <cooperative_groups.h>
+#include <cooperative_groups/reduce.h>
+namespace cg = cooperative_groups;
+
+#include "auxiliary.h"
+#include "forward.h"
+#include "backward.h"
+
+// Helper function to find the next-highest bit of the MSB
+// on the CPU.
+uint32_t getHigherMsb2(uint32_t n)
+{
+	uint32_t msb = sizeof(n) * 4;
+	uint32_t step = msb;
+	while (step > 1)
+	{
+		step /= 2;
+		if (n >> msb)
+			msb += step;
+		else
+			msb -= step;
+	}
+	if (n >> msb)
+		msb++;
+	return msb;
+}
+
+// Generates one key/value pair for all Gaussian / tile overlaps. 
+// Run once per Gaussian (1:N mapping).
+__global__ void duplicateWithKeys2(
+	int P,
+	const float3* points_xyz_vol,
+	const float* depths,
+	const uint32_t* offsets,
+	uint64_t* gaussian_keys_unsorted,
+	uint32_t* gaussian_values_unsorted,
+	int* radii,
+	dim3 grid)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= P)
+		return;
+
+	// Generate no key/value pair for invisible Gaussians
+	if (radii[idx] > 0)
+	{
+		// Find this Gaussian's offset in buffer for writing keys/values.
+		uint32_t off = (idx == 0) ? 0 : offsets[idx - 1];
+		uint3 cube_min, cube_max;
+
+		getCube(points_xyz_vol[idx], radii[idx], cube_min, cube_max, grid);
+
+		// For each tile that the bounding rect overlaps, emit a 
+		// key/value pair. The key is |  tile ID  |      depth      |,
+		// and the value is the ID of the Gaussian. Sorting the values 
+		// with this key yields Gaussian IDs in a list, such that they
+		// are first sorted by tile and then by depth. 
+		for (int z = cube_min.z; z < cube_max.z; z++)
+		{
+			for (int y = cube_min.y; y < cube_max.y; y++)
+			{
+				for (int x = cube_min.x; x < cube_max.x; x++)
+				{
+					uint64_t key = z * grid.y * grid.x + y * grid.x + x;
+					key <<= 32;
+					key |= *((uint32_t*)&depths[idx]);
+					gaussian_keys_unsorted[off] = key;
+					gaussian_values_unsorted[off] = idx;
+					off++;
+				}
+			}
+		}
+		
+	}
+}
+
+// Check keys to see if it is at the start/end of one tile's range in 
+// the full sorted list. If yes, write start/end of this tile. 
+// Run once per instanced (duplicated) Gaussian ID.
+__global__ void identifyTileRanges2(int L, uint64_t* point_list_keys, uint2* ranges)
+{
+	auto idx = cg::this_grid().thread_rank();
+	if (idx >= L)
+		return;
+
+	// Read tile ID from key. Update start/end of tile range if at limit.
+	uint64_t key = point_list_keys[idx];
+	uint32_t currtile = key >> 32;
+	if (idx == 0)
+		ranges[currtile].x = 0;
+	else
+	{
+		uint32_t prevtile = point_list_keys[idx - 1] >> 32;
+		if (currtile != prevtile)
+		{
+			ranges[prevtile].y = idx;
+			ranges[currtile].x = idx;
+		}
+	}
+	if (idx == L - 1)
+		ranges[currtile].y = L;
+}
+
+CudaVoxelizer::GeometryState CudaVoxelizer::GeometryState::fromChunk(char*& chunk, size_t P)
+{
+	GeometryState geom;
+	obtain(chunk, geom.depths, P, 128);
+	obtain(chunk, geom.internal_radii, P, 128);
+	obtain(chunk, geom.means3D_norm, P, 128);
+	obtain(chunk, geom.cov3D, P * 6, 128);
+	obtain(chunk, geom.conic_opacity, P * 7, 128);
+	obtain(chunk, geom.tiles_touched, P, 128);
+	cub::DeviceScan::InclusiveSum(nullptr, geom.scan_size, geom.tiles_touched, geom.tiles_touched, P);
+	obtain(chunk, geom.scanning_space, geom.scan_size, 128);
+	obtain(chunk, geom.point_offsets, P, 128);
+	return geom;
+}
+
+CudaVoxelizer::ImageState CudaVoxelizer::ImageState::fromChunk(char*& chunk, size_t N)
+{
+	ImageState img;
+	obtain(chunk, img.n_contrib, N, 128);
+	obtain(chunk, img.ranges, N, 128);
+	return img;
+}
+
+
+CudaVoxelizer::BinningState CudaVoxelizer::BinningState::fromChunk(char*& chunk, size_t P)
+{
+	BinningState binning;
+	obtain(chunk, binning.point_list, P, 128);
+	obtain(chunk, binning.point_list_unsorted, P, 128);
+	obtain(chunk, binning.point_list_keys, P, 128);
+	obtain(chunk, binning.point_list_keys_unsorted, P, 128);
+	cub::DeviceRadixSort::SortPairs(
+		nullptr, binning.sorting_size,
+		binning.point_list_keys_unsorted, binning.point_list_keys,
+		binning.point_list_unsorted, binning.point_list, P);
+	obtain(chunk, binning.list_sorting_space, binning.sorting_size, 128);
+	return binning;
+}
+
+int CudaVoxelizer::Voxelizer::forward(
+	std::function<char* (size_t)> geometryBuffer,
+	std::function<char* (size_t)> binningBuffer,
+	std::function<char* (size_t)> imageBuffer,
+	const int P, 
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float* means3D,
+	const float* opacities,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const bool prefiltered,
+	float* out_volume,
+	float* out_others,
+	int* radii,
+	bool debug)
+{
+
+	size_t chunk_size = required<GeometryState>(P);
+	char* chunkptr = geometryBuffer(chunk_size);
+	GeometryState geomState = GeometryState::fromChunk(chunkptr, P);
+	
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X, (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y, (nVoxel_z + BLOCK3D_Z - 1) / BLOCK3D_Z);
+	dim3 block(BLOCK3D_X, BLOCK3D_Y, BLOCK3D_Z);
+
+	// Dynamically resize image-based auxiliary buffers during training
+	size_t img_chunk_size = required<ImageState>(nVoxel_x * nVoxel_y * nVoxel_z);
+	char* img_chunkptr = imageBuffer(img_chunk_size);
+	ImageState imgState = ImageState::fromChunk(img_chunkptr, nVoxel_x * nVoxel_y * nVoxel_z);
+	
+
+	CHECK_CUDA(FORWARD::preprocess(
+		P,
+		means3D,
+		(glm::vec3*)scales,
+		scale_modifier,
+		(glm::vec4*)rotations,
+		opacities,
+		cov3D_precomp,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		radii,
+		geomState.means3D_norm,
+		geomState.depths,
+		geomState.cov3D,
+		geomState.conic_opacity,
+		tile_grid,
+		geomState.tiles_touched,
+		prefiltered
+	), debug);
+
+	// Compute prefix sum over full list of touched tile counts by Gaussians
+	// E.g., [2, 3, 0, 2, 1] -> [2, 5, 5, 7, 8]
+	CHECK_CUDA(cub::DeviceScan::InclusiveSum(geomState.scanning_space, geomState.scan_size, geomState.tiles_touched, geomState.point_offsets, P), debug);
+
+	// Retrieve total number of Gaussian instances to launch and resize aux buffers
+	int num_rendered;
+	CHECK_CUDA(cudaMemcpy(&num_rendered, geomState.point_offsets + P - 1, sizeof(int), cudaMemcpyDeviceToHost), debug);
+
+	size_t binning_chunk_size = required<BinningState>(num_rendered);
+	char* binning_chunkptr = binningBuffer(binning_chunk_size);
+	BinningState binningState = BinningState::fromChunk(binning_chunkptr, num_rendered);
+
+	// For each instance to be rendered, produce adequate [ tile | depth ] key 
+	// and corresponding dublicated Gaussian indices to be sorted
+	duplicateWithKeys2 << <(P + 255) / 256, 256 >> > (
+		P,
+		geomState.means3D_norm,
+		geomState.depths,
+		geomState.point_offsets,
+		binningState.point_list_keys_unsorted,
+		binningState.point_list_unsorted,
+		radii,
+		tile_grid)
+	CHECK_CUDA(, debug)
+
+	int bit = getHigherMsb2(tile_grid.x * tile_grid.y * tile_grid.z);
+
+	// Sort complete list of (duplicated) Gaussian indices by keys
+	CHECK_CUDA(cub::DeviceRadixSort::SortPairs(
+		binningState.list_sorting_space,
+		binningState.sorting_size,
+		binningState.point_list_keys_unsorted, binningState.point_list_keys,
+		binningState.point_list_unsorted, binningState.point_list,
+		num_rendered, 0, 32 + bit), debug)
+
+	CHECK_CUDA(cudaMemset(imgState.ranges, 0, tile_grid.x * tile_grid.y * tile_grid.z * sizeof(uint2)), debug);
+
+	// Identify start and end of per-tile workloads in sorted list
+	if (num_rendered > 0)
+		identifyTileRanges2 << <(num_rendered + 255) / 256, 256 >> > (
+			num_rendered,
+			binningState.point_list_keys,
+			imgState.ranges);
+	CHECK_CUDA(, debug)
+
+	// Let each tile blend its range of Gaussians independently in parallel
+	CHECK_CUDA(FORWARD::render(
+		tile_grid, block,
+		imgState.ranges,
+		binningState.point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		geomState.means3D_norm,
+		geomState.conic_opacity,
+		imgState.n_contrib,
+		out_volume,
+		out_others
+		), debug)
+
+	
+    return num_rendered;
+}
+
+
+// Produce necessary gradients for optimization, corresponding
+// to forward render pass
+void CudaVoxelizer::Voxelizer::backward(
+	const int P, int R, 
+	const int nVoxel_x, int nVoxel_y, int nVoxel_z,
+	const float sVoxel_x, float sVoxel_y, float sVoxel_z,
+	const float center_x, float center_y, float center_z,
+	const float* means3D,
+	const float* scales,
+	const float scale_modifier,
+	const float* rotations,
+	const float* cov3D_precomp,
+	const int* radii,
+	char* geom_buffer,
+	char* binning_buffer,
+	char* img_buffer,
+	const float* dL_dpix,
+	const float* dL_dothers,
+	float* dL_dmean3D_norm,
+	float* dL_dconic3D,
+	float* dL_dopacity,
+	float* dL_dmean3D,
+	float* dL_dcov3D,
+	float* dL_dscale,
+	float* dL_drot,
+	bool debug)
+{
+	GeometryState geomState = GeometryState::fromChunk(geom_buffer, P);
+	BinningState binningState = BinningState::fromChunk(binning_buffer, R);
+	ImageState imgState = ImageState::fromChunk(img_buffer, nVoxel_x * nVoxel_y * nVoxel_z);
+
+	if (radii == nullptr)
+	{
+		radii = geomState.internal_radii;
+	}
+
+	dim3 tile_grid((nVoxel_x + BLOCK3D_X - 1) / BLOCK3D_X, (nVoxel_y + BLOCK3D_Y - 1) / BLOCK3D_Y, (nVoxel_z + BLOCK3D_Z - 1) / BLOCK3D_Z);
+	dim3 block(BLOCK3D_X, BLOCK3D_Y, BLOCK3D_Z);
+
+	// Compute loss gradients w.r.t. 3D mean position, conic matrix,
+	// opacity.
+	CHECK_CUDA(BACKWARD::render(
+		tile_grid,
+		block,
+		imgState.ranges,
+		binningState.point_list,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		geomState.means3D_norm,
+		geomState.conic_opacity,
+		imgState.n_contrib,
+		dL_dpix,
+		dL_dothers,
+		(float3*)dL_dmean3D_norm,
+		dL_dconic3D,
+		dL_dopacity), debug)
+
+	const float* cov3D_ptr = (cov3D_precomp != nullptr) ? cov3D_precomp : geomState.cov3D;
+	CHECK_CUDA(BACKWARD::preprocess(P, 
+		(float3*)means3D,
+		radii,
+		(glm::vec3*)scales,
+		(glm::vec4*)rotations,
+		scale_modifier,
+		cov3D_ptr,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		(float3*)dL_dmean3D_norm,
+		dL_dconic3D,
+		(glm::vec3*)dL_dmean3D,
+		dL_dcov3D,
+		(glm::vec3*)dL_dscale,
+		(glm::vec4*)dL_drot), debug)
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/voxelizer_impl.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/cuda_voxelizer/voxelizer_impl.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include "voxelizer.h"
+#include <cuda_runtime_api.h>
+
+
+namespace CudaVoxelizer
+{
+	template <typename T>
+	static void obtain(char*& chunk, T*& ptr, std::size_t count, std::size_t alignment)
+	{
+		std::size_t offset = (reinterpret_cast<std::uintptr_t>(chunk) + alignment - 1) & ~(alignment - 1);
+		ptr = reinterpret_cast<T*>(offset);
+		chunk = reinterpret_cast<char*>(ptr + count);
+	}
+
+	struct GeometryState
+	{
+		size_t scan_size;
+		float* depths;
+		char* scanning_space;
+		int* internal_radii;
+		float3* means3D_norm;
+		float* cov3D;
+		float* conic_opacity;
+		uint32_t* point_offsets;
+		uint32_t* tiles_touched;
+
+		static GeometryState fromChunk(char*& chunk, size_t P);
+	};
+
+	struct ImageState
+	{
+		uint2* ranges;
+		uint32_t* n_contrib;
+
+		static ImageState fromChunk(char*& chunk, size_t N);
+	};
+
+	struct BinningState
+	{
+		size_t sorting_size;
+		uint64_t* point_list_keys_unsorted;
+		uint64_t* point_list_keys;
+		uint32_t* point_list_unsorted;
+		uint32_t* point_list;
+		char* list_sorting_space;
+
+		static BinningState fromChunk(char*& chunk, size_t P);
+	};
+
+	template<typename T> 
+	size_t required(size_t P)
+	{
+		char* size = nullptr;
+		T::fromChunk(size, P);
+		return ((size_t)size) + 128;
+	}
+};

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/diff_Xray_gaussian_rasterization_voxelization/__init__.py
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/diff_Xray_gaussian_rasterization_voxelization/__init__.py
@@ -1,0 +1,490 @@
+#
+# Copyright (C) 2023, Inria
+# GRAPHDECO research group, https://team.inria.fr/graphdeco
+# All rights reserved.
+#
+# This software is free for non-commercial, research and evaluation use
+# under the terms of the LICENSE.md file.
+#
+# For inquiries contact  george.drettakis@inria.fr
+#
+
+from typing import NamedTuple
+import torch.nn as nn
+import torch
+from . import _C
+import copy
+
+
+def cpu_deep_copy_tuple(input_tuple):
+    copied_tensors = [
+        item.cpu().clone() if isinstance(item, torch.Tensor) else item
+        for item in input_tuple
+    ]
+    return tuple(copied_tensors)
+
+
+def rasterize_gaussians(
+    means3D,
+    means2D,
+    opacities,
+    dummy_opacities,
+    scales,
+    rotations,
+    cov3Ds_precomp,
+    raster_settings,
+):
+    return _RasterizeGaussians.apply(
+        means3D,
+        means2D,
+        opacities,
+        dummy_opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        raster_settings,
+    )
+
+
+class _RasterizeGaussians(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        means3D,
+        means2D,
+        opacities,
+        dummy_opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        raster_settings,
+    ):
+
+        # Restructure arguments the way that the C++ lib expects them
+        args = (
+            means3D,
+            opacities,
+            scales,
+            rotations,
+            raster_settings.scale_modifier,
+            cov3Ds_precomp,
+            raster_settings.viewmatrix,
+            raster_settings.projmatrix,
+            raster_settings.tanfovx,
+            raster_settings.tanfovy,
+            raster_settings.image_height,
+            raster_settings.image_width,
+            raster_settings.campos,
+            raster_settings.prefiltered,
+            raster_settings.mode,
+            raster_settings.debug,
+        )
+
+        # Invoke C++/CUDA rasterizer
+        if raster_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                num_rendered, color, render_others, radii, geomBuffer, binningBuffer, imgBuffer = (
+                    _C.rasterize_gaussians(*args)
+                )
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_fw.dump")
+                print(
+                    "\nAn error occured in forward. Please forward snapshot_fw.dump for debugging."
+                )
+                raise ex
+        else:
+            num_rendered, color, render_others, radii, geomBuffer, binningBuffer, imgBuffer = (
+                _C.rasterize_gaussians(*args)
+            )
+
+        # Keep relevant tensors for backward
+        ctx.raster_settings = raster_settings
+        ctx.num_rendered = num_rendered
+        ctx.mode = raster_settings.mode
+        ctx.save_for_backward(
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        )
+        return color, radii, render_others
+
+    @staticmethod
+    def backward(ctx, grad_out_color, grad_radii, grad_others):
+
+        # Restore necessary values from context
+        num_rendered = ctx.num_rendered
+        raster_settings = ctx.raster_settings
+        mode = ctx.mode
+        (
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        ) = ctx.saved_tensors
+
+        # Restructure args as C++ method expects them
+        args = (
+            means3D,
+            radii,
+            scales,
+            rotations,
+            raster_settings.scale_modifier,
+            cov3Ds_precomp,
+            raster_settings.viewmatrix,
+            raster_settings.projmatrix,
+            raster_settings.tanfovx,
+            raster_settings.tanfovy,
+            grad_out_color,
+            raster_settings.campos,
+            geomBuffer,
+            num_rendered,
+            binningBuffer,
+            imgBuffer,
+            mode,
+            raster_settings.debug,
+        )
+
+        # Compute gradients for relevant tensors by invoking backward method
+        if raster_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                (
+                    grad_means2D,
+                    grad_opacities,
+                    grad_eta,  # grad_eta
+                    grad_means3D,
+                    grad_cov3Ds_precomp,
+                    grad_scales,
+                    grad_rotations,
+                ) = _C.rasterize_gaussians_backward(*args)
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_bw.dump")
+                print(
+                    "\nAn error occured in backward. Writing snapshot_bw.dump for debugging.\n"
+                )
+                raise ex
+        else:
+            (
+                grad_means2D,
+                grad_opacities,
+                grad_eta,
+                grad_means3D,
+                grad_cov3Ds_precomp,
+                grad_scales,
+                grad_rotations,
+            ) = _C.rasterize_gaussians_backward(*args)
+        grad_dummy_opacities = copy.deepcopy(grad_opacities)
+        grads = (
+            grad_means3D,
+            grad_means2D,
+            grad_opacities,
+            grad_dummy_opacities,
+            grad_scales,
+            grad_rotations,
+            grad_cov3Ds_precomp,
+            None,
+        )
+
+        return grads
+
+
+# Change according to line 45 gaussian_renderer/__init__.py
+class GaussianRasterizationSettings(NamedTuple):
+    image_height: int
+    image_width: int
+    tanfovx: float
+    tanfovy: float
+    scale_modifier: float
+    viewmatrix: torch.Tensor
+    projmatrix: torch.Tensor
+    campos: torch.Tensor
+    prefiltered: bool
+    mode: int
+    debug: bool
+
+
+class GaussianRasterizer(nn.Module):
+    def __init__(self, raster_settings):
+        super().__init__()
+        self.raster_settings = raster_settings
+
+    def markVisible(self, positions):
+        # Mark visible points (based on frustum culling for camera) with a boolean
+        with torch.no_grad():
+            raster_settings = self.raster_settings
+            visible = _C.mark_visible(
+                positions, raster_settings.viewmatrix, raster_settings.projmatrix
+            )
+
+        return visible
+
+    def forward(
+        self,
+        means3D,
+        means2D,
+        opacities,
+        dummy_opacities,
+        scales=None,
+        rotations=None,
+        cov3D_precomp=None,
+    ):
+
+        raster_settings = self.raster_settings
+
+        if ((scales is None or rotations is None) and cov3D_precomp is None) or (
+            (scales is not None or rotations is not None) and cov3D_precomp is not None
+        ):
+            raise Exception(
+                "Please provide exactly one of either scale/rotation pair or precomputed 3D covariance!"
+            )
+
+        if scales is None:
+            scales = torch.Tensor([])
+        if rotations is None:
+            rotations = torch.Tensor([])
+        if cov3D_precomp is None:
+            cov3D_precomp = torch.Tensor([])
+
+        # Invoke C++/CUDA rasterization routine
+        return rasterize_gaussians(
+            means3D,
+            means2D,
+            opacities,
+            dummy_opacities,
+            scales,
+            rotations,
+            cov3D_precomp,
+            raster_settings,
+        )
+
+
+class GaussianVoxelizationSettings(NamedTuple):
+    scale_modifier: float
+    nVoxel_x: int
+    nVoxel_y: int
+    nVoxel_z: int
+    sVoxel_x: float
+    sVoxel_y: float
+    sVoxel_z: float
+    center_x: float
+    center_y: float
+    center_z: float
+    prefiltered: bool
+    debug: bool
+
+
+def voxelize_gaussians(
+    means3D, opacities, scales, rotations, cov3Ds_precomp, voxel_settings
+):
+    return _VoxelizeGaussians.apply(
+        means3D,
+        opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        voxel_settings,
+    )
+
+
+class _VoxelizeGaussians(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        means3D,
+        opacities,
+        scales,
+        rotations,
+        cov3Ds_precomp,
+        voxel_settings,
+    ):
+        # Restructure arguments the way that the C++ lib expects them
+        args = (
+            means3D,
+            opacities,
+            scales,
+            rotations,
+            voxel_settings.scale_modifier,
+            cov3Ds_precomp,
+            voxel_settings.nVoxel_x,
+            voxel_settings.nVoxel_y,
+            voxel_settings.nVoxel_z,
+            voxel_settings.sVoxel_x,
+            voxel_settings.sVoxel_y,
+            voxel_settings.sVoxel_z,
+            voxel_settings.center_x,
+            voxel_settings.center_y,
+            voxel_settings.center_z,
+            voxel_settings.prefiltered,
+            voxel_settings.debug,
+        )
+
+        # Invoke C++/CUDA rasterizer
+        if voxel_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                num_rendered, color, voxel_others, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+                # num_rendered, color, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_fw.dump")
+                print(
+                    "\nAn error occured in forward. Please forward snapshot_fw.dump for debugging."
+                )
+                raise ex
+        else:
+            num_rendered, color, voxel_others, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+            # num_rendered, color, radii, geomBuffer, binningBuffer, imgBuffer = (_C.voxelize_gaussians(*args))
+
+        # Keep relevant tensors for backward
+        ctx.voxel_settings = voxel_settings
+        ctx.num_rendered = num_rendered
+        ctx.save_for_backward(
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        )
+
+        return color, radii, voxel_others
+        # return color, radii
+
+    @staticmethod
+    def backward(ctx, grad_out_color, grad_radii, grad_others):
+    # def backward(ctx, grad_out_color, grad_radii):
+
+        # Restore necessary values from context
+        num_rendered = ctx.num_rendered
+        voxel_settings = ctx.voxel_settings
+        (
+            means3D,
+            scales,
+            rotations,
+            cov3Ds_precomp,
+            radii,
+            geomBuffer,
+            binningBuffer,
+            imgBuffer,
+        ) = ctx.saved_tensors
+
+        args = (
+            means3D,
+            radii,
+            scales,
+            rotations,
+            voxel_settings.scale_modifier,
+            cov3Ds_precomp,
+            grad_out_color,
+            grad_others,
+            geomBuffer,
+            num_rendered,
+            binningBuffer,
+            imgBuffer,
+            voxel_settings.nVoxel_x,
+            voxel_settings.nVoxel_y,
+            voxel_settings.nVoxel_z,
+            voxel_settings.sVoxel_x,
+            voxel_settings.sVoxel_y,
+            voxel_settings.sVoxel_z,
+            voxel_settings.center_x,
+            voxel_settings.center_y,
+            voxel_settings.center_z,
+            voxel_settings.debug,
+        )
+
+        # Compute gradients for relevant tensors by invoking backward method
+        if voxel_settings.debug:
+            cpu_args = cpu_deep_copy_tuple(
+                args
+            )  # Copy them before they can be corrupted
+            try:
+                (
+                    grad_opacities,
+                    grad_means3D,
+                    grad_cov3Ds_precomp,
+                    grad_scales,
+                    grad_rotations,
+                ) = _C.voxelize_gaussians_backward(*args)
+            except Exception as ex:
+                torch.save(cpu_args, "snapshot_bw.dump")
+                print(
+                    "\nAn error occured in backward. Writing snapshot_bw.dump for debugging.\n"
+                )
+                raise ex
+        else:
+            (
+                grad_opacities,
+                grad_means3D,
+                grad_cov3Ds_precomp,
+                grad_scales,
+                grad_rotations,
+            ) = _C.voxelize_gaussians_backward(*args)
+        grads = (
+            grad_means3D,
+            grad_opacities,
+            grad_scales,
+            grad_rotations,
+            grad_cov3Ds_precomp,
+            None,
+        )
+
+        return grads
+
+
+class GaussianVoxelizer(nn.Module):
+    def __init__(self, voxel_settings):
+        super().__init__()
+        self.voxel_settings = voxel_settings
+
+    def forward(
+        self,
+        means3D,
+        opacities,
+        scales=None,
+        rotations=None,
+        cov3D_precomp=None,
+    ):
+
+        voxel_settings = self.voxel_settings
+
+        if ((scales is None or rotations is None) and cov3D_precomp is None) or (
+            (scales is not None or rotations is not None) and cov3D_precomp is not None
+        ):
+            raise Exception(
+                "Please provide exactly one of either scale/rotation pair or precomputed 3D covariance!"
+            )
+
+        if scales is None:
+            scales = torch.Tensor([])
+        if rotations is None:
+            rotations = torch.Tensor([])
+        if cov3D_precomp is None:
+            cov3D_precomp = torch.Tensor([])
+
+        # Invoke C++/CUDA rasterization routine
+        return voxelize_gaussians(
+            means3D,
+            opacities,
+            scales,
+            rotations,
+            cov3D_precomp,
+            voxel_settings,
+        )

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/ext.cpp
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/ext.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <torch/extension.h>
+#include "rasterize_points.h"
+#include "voxelize_points.h"
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("rasterize_gaussians", &RasterizeGaussiansCUDA);
+  m.def("rasterize_gaussians_backward", &RasterizeGaussiansBackwardCUDA);
+  m.def("voxelize_gaussians", &VoxelizeGaussiansCUDA);
+  m.def("voxelize_gaussians_backward", &VoxelizeGaussiansBackwardCUDA);
+  m.def("mark_visible", &markVisible);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/rasterize_points.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/rasterize_points.cu
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <math.h>
+#include <torch/extension.h>
+#include <cstdio>
+#include <sstream>
+#include <iostream>
+#include <tuple>
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include <memory>
+#include "cuda_rasterizer/config.h"
+#include "cuda_rasterizer/rasterizer.h"
+#include <fstream>
+#include <string>
+#include <functional>
+
+std::function<char*(size_t N)> resizeFunctional(torch::Tensor& t) {
+    auto lambda = [&t](size_t N) {
+        t.resize_({(long long)N});
+		return reinterpret_cast<char*>(t.contiguous().data_ptr());
+    };
+    return lambda;
+}
+
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+RasterizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+	const torch::Tensor& projmatrix,
+	const float tan_fovx, 
+	const float tan_fovy,
+    const int image_height,
+    const int image_width,
+	const torch::Tensor& campos,
+	const bool prefiltered,
+	const int mode,  // Scanner mode (0: parallel beam, 1: cone beam)
+	const bool debug)
+{
+  if (means3D.ndimension() != 2 || means3D.size(1) != 3) {
+    AT_ERROR("means3D must have dimensions (num_points, 3)");
+  }
+  
+  const int P = means3D.size(0);
+  const int H = image_height;
+  const int W = image_width;
+
+  auto int_opts = means3D.options().dtype(torch::kInt32);
+  auto float_opts = means3D.options().dtype(torch::kFloat32);
+
+  torch::Tensor out_color = torch::full({NUM_CHANNELS, H, W}, 0.0, float_opts);
+  torch::Tensor out_others = torch::full({NUM_OTHERS, H, W}, 0.0, float_opts);
+  torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
+  
+  torch::Device device(torch::kCUDA);
+  torch::TensorOptions options(torch::kByte);
+  torch::Tensor geomBuffer = torch::empty({0}, options.device(device));
+  torch::Tensor binningBuffer = torch::empty({0}, options.device(device));
+  torch::Tensor imgBuffer = torch::empty({0}, options.device(device));
+  std::function<char*(size_t)> geomFunc = resizeFunctional(geomBuffer);
+  std::function<char*(size_t)> binningFunc = resizeFunctional(binningBuffer);
+  std::function<char*(size_t)> imgFunc = resizeFunctional(imgBuffer);
+  
+  int rendered = 0;
+  if(P != 0)
+  {
+	rendered = CudaRasterizer::Rasterizer::forward(
+	    geomFunc,
+		binningFunc,
+		imgFunc,
+	    P, 
+		W, H,
+		means3D.contiguous().data<float>(),
+		opacity.contiguous().data<float>(), 
+		scales.contiguous().data_ptr<float>(),
+		scale_modifier,
+		rotations.contiguous().data_ptr<float>(),
+		cov3D_precomp.contiguous().data<float>(), 
+		viewmatrix.contiguous().data<float>(), 
+		projmatrix.contiguous().data<float>(),
+		campos.contiguous().data<float>(),
+		tan_fovx,
+		tan_fovy,
+		prefiltered,
+		mode,
+		out_color.contiguous().data<float>(),
+		out_others.contiguous().data<float>(),
+		radii.contiguous().data<int>(),
+		debug);
+  }
+  return std::make_tuple(rendered, out_color, out_others, radii, geomBuffer, binningBuffer, imgBuffer);
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+ RasterizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+    const torch::Tensor& projmatrix,
+	const float tan_fovx,
+	const float tan_fovy,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& campos,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int mode,
+	const bool debug) 
+{
+  const int P = means3D.size(0);
+  const int H = dL_dout_color.size(1);
+  const int W = dL_dout_color.size(2);
+  
+  torch::Tensor dL_dmeans3D = torch::zeros({P, 3}, means3D.options());
+  torch::Tensor dL_dmeans2D = torch::zeros({P, 3}, means3D.options());
+  torch::Tensor dL_dconic = torch::zeros({P, 2, 2}, means3D.options());
+  torch::Tensor dL_dopacity = torch::zeros({P, 1}, means3D.options());
+  torch::Tensor dL_deta = torch::zeros({P, 1}, means3D.options()); 
+  torch::Tensor dL_dcov3D = torch::zeros({P, 6}, means3D.options());
+  torch::Tensor dL_dscales = torch::zeros({P, 3}, means3D.options());
+  torch::Tensor dL_drotations = torch::zeros({P, 4}, means3D.options());
+  
+  if(P != 0)
+  {   
+	  CudaRasterizer::Rasterizer::backward(P, R,
+	  W, H, 
+	  means3D.contiguous().data<float>(),
+	  scales.data_ptr<float>(),
+	  scale_modifier,
+	  rotations.data_ptr<float>(),
+	  cov3D_precomp.contiguous().data<float>(),
+	  viewmatrix.contiguous().data<float>(),
+	  projmatrix.contiguous().data<float>(),
+	  campos.contiguous().data<float>(),
+	  tan_fovx,
+	  tan_fovy,
+	  radii.contiguous().data<int>(),
+	  reinterpret_cast<char*>(geomBuffer.contiguous().data_ptr()),
+	  reinterpret_cast<char*>(binningBuffer.contiguous().data_ptr()),
+	  reinterpret_cast<char*>(imageBuffer.contiguous().data_ptr()),
+	  dL_dout_color.contiguous().data<float>(),
+	  dL_dmeans2D.contiguous().data<float>(),
+	  dL_dconic.contiguous().data<float>(),  
+	  dL_dopacity.contiguous().data<float>(),
+	  dL_deta.contiguous().data<float>(),
+	  dL_dmeans3D.contiguous().data<float>(),
+	  dL_dcov3D.contiguous().data<float>(),
+	  dL_dscales.contiguous().data<float>(),
+	  dL_drotations.contiguous().data<float>(),
+	  mode,
+	  debug);
+  }
+  return std::make_tuple(dL_dmeans2D, dL_dopacity, dL_deta, dL_dmeans3D, dL_dcov3D, dL_dscales, dL_drotations);
+}
+
+torch::Tensor markVisible(
+		torch::Tensor& means3D,
+		torch::Tensor& viewmatrix,
+		torch::Tensor& projmatrix)
+{ 
+  const int P = means3D.size(0);
+  
+  torch::Tensor present = torch::full({P}, false, means3D.options().dtype(at::kBool));
+ 
+  if(P != 0)
+  {
+	CudaRasterizer::Rasterizer::markVisible(P,
+		means3D.contiguous().data<float>(),
+		viewmatrix.contiguous().data<float>(),
+		projmatrix.contiguous().data<float>(),
+		present.contiguous().data<bool>());
+  }
+  
+  return present;
+}
+

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/rasterize_points.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/rasterize_points.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+#include <torch/extension.h>
+#include <cstdio>
+#include <tuple>
+#include <string>
+
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+RasterizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+	const torch::Tensor& projmatrix,
+	const float tan_fovx, 
+	const float tan_fovy,
+    const int image_height,
+    const int image_width,
+	const torch::Tensor& campos,
+	const bool prefiltered,
+	const int mode,
+	const bool debug);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+RasterizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const torch::Tensor& viewmatrix,
+    const torch::Tensor& projmatrix,
+	const float tan_fovx, 
+	const float tan_fovy,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& campos,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int mode,
+	const bool debug);
+		
+torch::Tensor markVisible(
+		torch::Tensor& means3D,
+		torch::Tensor& viewmatrix,
+		torch::Tensor& projmatrix);
+

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/setup.py
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/setup.py
@@ -1,0 +1,46 @@
+#
+# Copyright (C) 2023, Inria
+# GRAPHDECO research group, https://team.inria.fr/graphdeco
+# All rights reserved.
+#
+# This software is free for non-commercial, research and evaluation use
+# under the terms of the LICENSE.md file.
+#
+# For inquiries contact  george.drettakis@inria.fr
+#
+
+from setuptools import setup
+from torch.utils.cpp_extension import CUDAExtension, BuildExtension
+import os
+
+os.path.dirname(os.path.abspath(__file__))
+
+setup(
+    name="diff_Xray_gaussian_rasterization_voxelization",
+    packages=["diff_Xray_gaussian_rasterization_voxelization"],
+    ext_modules=[
+        CUDAExtension(
+            name="diff_Xray_gaussian_rasterization_voxelization._C",
+            sources=[
+                "cuda_rasterizer/rasterizer_impl.cu",
+                "cuda_rasterizer/forward.cu",
+                "cuda_rasterizer/backward.cu",
+                "rasterize_points.cu",
+                "cuda_voxelizer/voxelizer_impl.cu",
+                "cuda_voxelizer/forward.cu",
+                "cuda_voxelizer/backward.cu",
+                "voxelize_points.cu",
+                "ext.cpp",
+            ],
+            extra_compile_args={
+                "nvcc": [
+                    "-I"
+                    + os.path.join(
+                        os.path.dirname(os.path.abspath(__file__)), "../diff-Xray-gaussian-rasterization-voxelization/third_party/glm/"
+                    )
+                ]
+            },
+        )
+    ],
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/voxelize_points.cu
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/voxelize_points.cu
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#include <math.h>
+#include <torch/extension.h>
+#include <cstdio>
+#include <sstream>
+#include <iostream>
+#include <tuple>
+#include <stdio.h>
+#include <cuda_runtime_api.h>
+#include <memory>
+#include "cuda_voxelizer/config.h"
+#include "cuda_voxelizer/voxelizer.h"
+#include <fstream>
+#include <string>
+#include <functional>
+
+
+std::function<char*(size_t N)> resizeFunctional2(torch::Tensor& t) {
+    auto lambda = [&t](size_t N) {
+        t.resize_({(long long)N});
+		return reinterpret_cast<char*>(t.contiguous().data_ptr());
+    };
+    return lambda;
+}
+
+// std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool prefiltered,
+	const bool debug)
+{
+	if (means3D.ndimension() != 2 || means3D.size(1) != 3) {
+		AT_ERROR("means3D must have dimensions (num_points, 3)");
+	}
+
+	const int P = means3D.size(0);
+
+    auto int_opts = means3D.options().dtype(torch::kInt32);
+    auto float_opts = means3D.options().dtype(torch::kFloat32);
+
+	torch::Tensor out_volume = torch::full({nVoxel_x, nVoxel_y, nVoxel_z}, 0.0, float_opts);
+	torch::Tensor out_others = torch::full({nVoxel_x, nVoxel_y, nVoxel_z}, 0.0, float_opts);
+	torch::Tensor radii = torch::full({P}, 0, means3D.options().dtype(torch::kInt32));
+	
+	torch::Device device(torch::kCUDA);
+	torch::TensorOptions options(torch::kByte);
+	torch::Tensor geomBuffer = torch::empty({0}, options.device(device));
+	torch::Tensor binningBuffer = torch::empty({0}, options.device(device));
+	torch::Tensor imgBuffer = torch::empty({0}, options.device(device));
+	std::function<char*(size_t)> geomFunc = resizeFunctional2(geomBuffer);
+	std::function<char*(size_t)> binningFunc = resizeFunctional2(binningBuffer);
+	std::function<char*(size_t)> imgFunc = resizeFunctional2(imgBuffer);
+	
+	int rendered = 0;
+	if(P != 0)
+  	{
+		rendered = CudaVoxelizer::Voxelizer::forward(
+            geomFunc,
+            binningFunc,
+			imgFunc,
+            P, 
+			nVoxel_x, nVoxel_y, nVoxel_z,
+			sVoxel_x, sVoxel_y, sVoxel_z,
+			center_x, center_y, center_z,
+            means3D.contiguous().data<float>(),
+            opacity.contiguous().data<float>(), 
+            scales.contiguous().data_ptr<float>(),
+            scale_modifier,
+            rotations.contiguous().data_ptr<float>(),
+            cov3D_precomp.contiguous().data<float>(), 
+            prefiltered,
+            out_volume.contiguous().data<float>(),
+			out_others.contiguous().data<float>(),
+            radii.contiguous().data<int>(),
+            debug);
+	}
+
+	return std::make_tuple(rendered, out_volume, out_others, radii, geomBuffer, binningBuffer, imgBuffer);
+	// return std::make_tuple(rendered, out_volume, radii, geomBuffer, binningBuffer, imgBuffer);
+}
+
+
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& dL_dout_others,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool debug)
+{
+	const int P = means3D.size(0);
+
+	torch::Tensor dL_dmeans3D = torch::zeros({P, 3}, means3D.options());
+	torch::Tensor dL_dmeans3D_norm = torch::zeros({P, 3}, means3D.options());
+	torch::Tensor dL_dconic3D = torch::zeros({P, 6}, means3D.options());
+	torch::Tensor dL_dopacity = torch::zeros({P, 1}, means3D.options());
+	torch::Tensor dL_dcov3D = torch::zeros({P, 6}, means3D.options());
+	torch::Tensor dL_dscales = torch::zeros({P, 3}, means3D.options());
+	torch::Tensor dL_drotations = torch::zeros({P, 4}, means3D.options());
+
+	if(P != 0)
+	{   
+		CudaVoxelizer::Voxelizer::backward(P, R,
+		nVoxel_x, nVoxel_y, nVoxel_z,
+		sVoxel_x, sVoxel_y, sVoxel_z,
+		center_x, center_y, center_z,
+		means3D.contiguous().data<float>(),
+		scales.data_ptr<float>(),
+		scale_modifier,
+		rotations.data_ptr<float>(),
+		cov3D_precomp.contiguous().data<float>(),
+		radii.contiguous().data<int>(),
+		reinterpret_cast<char*>(geomBuffer.contiguous().data_ptr()),
+		reinterpret_cast<char*>(binningBuffer.contiguous().data_ptr()),
+		reinterpret_cast<char*>(imageBuffer.contiguous().data_ptr()),
+		dL_dout_color.contiguous().data<float>(),
+		dL_dout_others.contiguous().data<float>(),
+		dL_dmeans3D_norm.contiguous().data<float>(),  
+		dL_dconic3D.contiguous().data<float>(),  
+		dL_dopacity.contiguous().data<float>(),
+		dL_dmeans3D.contiguous().data<float>(),
+		dL_dcov3D.contiguous().data<float>(),
+		dL_dscales.contiguous().data<float>(),
+		dL_drotations.contiguous().data<float>(),
+		debug);
+	}
+
+	return std::make_tuple(dL_dopacity, dL_dmeans3D, dL_dcov3D, dL_dscales, dL_drotations);
+}

--- a/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/voxelize_points.h
+++ b/submodules/diff-Xray-gaussian-rasterization-voxelization-sortfree/voxelize_points.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023, Inria
+ * GRAPHDECO research group, https://team.inria.fr/graphdeco
+ * All rights reserved.
+ *
+ * This software is free for non-commercial, research and evaluation use 
+ * under the terms of the LICENSE.md file.
+ *
+ * For inquiries contact  george.drettakis@inria.fr
+ */
+
+#pragma once
+#include <torch/extension.h>
+#include <cstdio>
+#include <tuple>
+#include <string>
+
+// std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<int, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansCUDA(
+	const torch::Tensor& means3D,
+    const torch::Tensor& opacity,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool prefiltered,
+	const bool debug);
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+VoxelizeGaussiansBackwardCUDA(
+	const torch::Tensor& means3D,
+	const torch::Tensor& radii,
+	const torch::Tensor& scales,
+	const torch::Tensor& rotations,
+	const float scale_modifier,
+	const torch::Tensor& cov3D_precomp,
+    const torch::Tensor& dL_dout_color,
+	const torch::Tensor& dL_dout_others,
+	const torch::Tensor& geomBuffer,
+	const int R,
+	const torch::Tensor& binningBuffer,
+	const torch::Tensor& imageBuffer,
+	const int nVoxel_x,
+    const int nVoxel_y,
+    const int nVoxel_z,
+    const float sVoxel_x,
+    const float sVoxel_y,
+    const float sVoxel_z,
+    const float center_x,
+    const float center_y,
+    const float center_z,
+	const bool debug);


### PR DESCRIPTION
## Summary

- add a sort-free X-ray rasterization backend that removes tile duplication, prefix-sum, and depth sorting for additive line-integral accumulation
- keep the original rasterizer as the `legacy` backend
- add `--rasterizer_backend {sort_free,legacy}` behavior through the existing argument system, with `sort_free` as the default
- document installation and local case2 results; no timing or benchmark instrumentation is added to the codebase

## Local results

Measured on case2 with 30 input views on an NVIDIA RTX 4060 Ti:

| Iterations / ADC until | Backend | Runtime (s) | Eval PSNR | Eval SSIM |
| --- | --- | ---: | ---: | ---: |
| 10k / 5k | Legacy | 453.10 | 36.343 | 0.9026 |
| 10k / 5k | Sort-free | 383.51 | 36.349 | 0.9021 |
| 30k / 15k | Legacy | 1380.66 | 36.343 | 0.9032 |
| 30k / 15k | Sort-free | 1175.09 | 36.407 | 0.9031 |

This corresponds to 1.18x and 1.17x speedups. The paper's absolute runtime was measured on an RTX 3090 and includes final voxelization/rendering, so it is not directly compared with the local RTX 4060 Ti runtime.

## Validation

- both installed CUDA backends import successfully
- parser selects `sort_free` by default and `legacy` when requested
- Python source and setup files pass syntax checks
- package names from both setup files are correct
- same-initialization projection check: mean absolute difference `5.36e-10`; radii exactly equal
- tested mean-2D and opacity gradients pass `rtol=1e-4, atol=1e-6`
